### PR TITLE
actions: Only fmt-check and lint python on Ubuntu

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -42,9 +42,11 @@ jobs:
       run: make init-python
 
     - name: Check Python formatting
+      if: matrix.os == 'ubuntu-20.04'
       run: make fmt-check-python
 
     - name: Lint Python code
+      if: matrix.os == 'ubuntu-20.04'
       run: make lint-python
 
     - name: Run Python tests


### PR DESCRIPTION
There is no reason to run formatting or linting checks on multiple operating systems at once.