### PR TITLE
Don't run resampler comparison on every commit

### DIFF
--- a/.github/workflows/example-resampler-comparison.yml
+++ b/.github/workflows/example-resampler-comparison.yml
@@ -4,11 +4,7 @@ defaults:
   run:
     shell: bash
 
-on:
-  pull_request:
-  push:
-    tags-ignore:
-      - 'v*' # Don't run these tests twice when cutting a new version.
+on: workflow_dispatch
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The `example-resampler-comparison` GitHub action can take quite a while, so now we will only run it on request.