### PR TITLE
Add Netlify Docker image to docker-compose.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ else
 endif
 
 
-.PHONY: help clean init-javascript init-rust init vendor fmt-c fmt-javascript fmt-python fmt-rust fmt fmt-check-javascript fmt-check-python fmt-check-rust fmt-check lint-rust lint cargo-build-release-all-features cargo-build-release-frontend-rust cargo-build-release-frontend-wasm cargo-build-release-frontend-c babycat.h build-python install-babycat-python build-rust build-wasm-bundler build-wasm-nodejs build-wasm-web build test-c test-c-valgrind test-rust test-wasm-nodejs test doctest-python doctest-rust doctest bench-rust bench example-resampler-comparison example-decode-rust example-decode-python example-decode-c docker-build-cargo docker-build-ubuntu-minimal docker-build-main docker-build-pip docker-build
+.PHONY: help clean init-javascript init-rust init vendor fmt-c fmt-javascript fmt-python fmt-rust fmt fmt-check-javascript fmt-check-python fmt-check-rust fmt-check lint-rust lint cargo-build-release-all-features cargo-build-release-frontend-rust cargo-build-release-frontend-wasm cargo-build-release-frontend-c babycat.h build-python install-babycat-python build-rust build-wasm-bundler build-wasm-nodejs build-wasm-web build test-c test-c-valgrind test-rust test-wasm-nodejs test doctest-python doctest-rust doctest bench-rust bench example-resampler-comparison example-decode-rust example-decode-python example-decode-c docker-build-cargo docker-build-ubuntu-minimal docker-build-main docker-build-pip docker-build docker-run-docs-netlify
 
 
 # help ==============================================================
@@ -340,7 +340,7 @@ example-decode-c: babycat.h cargo-build-release-frontend-c
 	./target/decode_c
 
 
-# docker ============================================================
+# docker build ======================================================
 
 docker/rust/.ti: docker-compose.yml docker/rust/Dockerfile
 	$(DOCKER_COMPOSE) build cargo
@@ -367,3 +367,9 @@ docker-build-main: docker/main/.ti
 docker-build-pip: docker/pip/.ti
 
 docker-build: docker-build-cargo docker-build-ubuntu-minimal docker-build-main docker-build-pip
+
+
+# docker run ========================================================
+
+docker-run-docs-netlify:
+	$(DOCKER_COMPOSE) run --rm netlify

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,3 +61,19 @@ services:
       - type: bind
         source: "."
         target: /io
+
+  # A local copy of the Netlify build image.
+  # Used to test the `make docs-netlify` build command.
+  netlify:
+    image: netlify/build:focal
+    init: true
+    network_mode: host
+    entrypoint: /opt/build-bin/build
+    command: "make docs-netlify"
+    working_dir: /opt/buildhome/repo
+    environment:
+      PYTHON_VERSION: "3.8"
+    volumes:
+      - type: bind
+        source: "."
+        target: /opt/buildhome/repo

--- a/makefile-help.txt
+++ b/makefile-help.txt
@@ -103,3 +103,8 @@ docker-build-main               - main: Many versions of Python and
 
 docker-build-pip                - pip: A container for building
                                   manylinux images.
+
+--
+docker-run-docs-netlify         Runs our documentation build rule
+                                inside of a copy of Netlify's
+                                build image.


### PR DESCRIPTION
We can use the Netlify Docker Build Image to locally simulate Netlify deploys. It can help make sure that our documentation-generating code works.