### PR TITLE
Mention feature flags in the Rust documentation

### DIFF
--- a/src/backend/float_waveform.rs
+++ b/src/backend/float_waveform.rs
@@ -139,6 +139,12 @@ impl FloatWaveform {
     /// - `filename`: A filename of an encoded audio file on the local filesystem.
     /// - `decode_args`: Instructions on how to decode the audio.
     ///
+    /// # Feature flags
+    /// This function is only available if the Cargo feature `enable-fileystem`
+    /// flag is enabled. The `enable-filesystem` flag is enabled by default
+    /// for the Babycat's Rust, Python, and C frontends, but is disabled
+    /// for the WebAssembly frontend.
+    ///
     /// # Examples
     /// **Decode one audio file with the default decoding arguments:**
     /// ```
@@ -214,6 +220,12 @@ impl FloatWaveform {
     /// - `filenames`: A filename of an encoded audio file on the local filesystem.
     /// - `decode_args`: Instructions on how to decode the audio.
     /// - `batch_args`: Instructions on how to divide the work across multiple threads.
+    ///
+    /// # Feature flags
+    /// This function is only available if both of the `enable-filesystem`
+    /// and `enable-multithreading` features are enabled. These features
+    /// are enabled by default in Babycat's Rust, Python, and C frontends.
+    /// These features are disabled in Babycat's WebAssembly frontend.
     ///
     /// # Examples
     /// **(Attempt to) decode three files:**
@@ -738,6 +750,13 @@ impl FloatWaveform {
     }
 
     /// Writes the waveform to the filesystem as a WAV file.
+    ///
+    /// # Feature flags
+    /// This function is only available if the Cargo feature `enable-fileystem`
+    /// flag is enabled. The `enable-filesystem` flag is enabled by default
+    /// for the Babycat's Rust, Python, and C frontends, but is disabled
+    /// for the WebAssembly frontend.
+    ///
     #[cfg(feature = "enable-filesystem")]
     pub fn to_wav_file(&self, filename: &str) -> Result<(), Error> {
         let writer_spec = hound::WavSpec {

--- a/src/backend/resample/libsamplerate.rs
+++ b/src/backend/resample/libsamplerate.rs
@@ -9,6 +9,14 @@ use crate::backend::errors::Error;
 #[cfg(feature = "enable-libsamplerate")]
 use crate::backend::resample::common::validate_args;
 
+/// Resample input audio from one sample rate to another.
+///
+/// # Feature flags
+/// This function is only available if the Cargo feature `enable-libsamplerate`
+/// flag is enabled. The `enable-libsamplerate` flag is enabled by default
+/// for the Babycat's Rust, Python, and C frontends, but is disabled
+/// for the WebAssembly frontend.
+///
 #[allow(unused_variables)]
 pub fn resample(
     input_frame_rate_hz: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,12 @@
 //!   This uses [libsamplerate](http://www.mega-nerd.com/SRC/) at the
 //!   `SRC_SINC_BEST_QUALITY` setting. This is the highest-quality resampler
 //!   currently offered by Babycat, although it is slightly slower than the other
-//!   resamplers. This option is only available if
-//!   it is enabled at compile-time, and is disabled for targets
-//!   missing a libc, such as the WebAssembly `wasm32-unknown-unknown` target.
-//!   This backend can be enabled or disabled at compile-time using the
-//!   Cargo feature `enable-libsamplerate`. It is enabled by default on
-//!   all platforms except WebAssembly. The libsamplerate library is written
-//!   in C and its dependence on libc makes it currently not possible
-//!   to compile libsamplerate to the `wasm32-unknown-unknown` target.
+//!   resamplers. This resampler is only available when Babycat is compiled with
+//!  the Cargo feature `enable-libsamplerate` enabled. This feature is enabled
+//!   by default in Babycat's C, Python, and Rust frontends. The libsamplerate
+//!   resampler is currently unavailable in Babycat's WebAssembly frontend
+//!   because libsamplerate's dependency on libc makes it hard to compile
+//!   it to the `wasm32-unknown-unknown` target.
 //!
 //! * [`babycat::RESAMPLE_MODE_BABYCAT_LANCZOS`](crate::RESAMPLE_MODE_BABYCAT_LANCZOS):
 //!   A Lanczos resampler to use when compiling to targets like


### PR DESCRIPTION
Document when documented Rust functions need to be enabled via Cargo features.