### PR TITLE
Remove 1152 frames of silence from decoded MP3 FloatWaveforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,14 @@ wasm-bindgen-test = "0.3"
 criterion = { version = "0.3", features = ["html_reports"] }
 
 [dependencies.symphonia]
-version = "0.3"
+git = "https://github.com/neocrym-forks/Symphonia"
+
+# latest tagged release. MP3 files begin with 0s.
+#tag = "v0.3.0"
+
+# latest commit where MP3 files begin with zeros.
+rev = "2cafae82b664ceb14dd5d058f534574399764165"
+
 features = [
     "aac",
     "flac",

--- a/src/backend/int_waveform.rs
+++ b/src/backend/int_waveform.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 /// ).unwrap();
 /// assert_eq!(
 ///     format!("{:?}", float_waveform),
-///     "FloatWaveform { frame_rate_hz: 44100, num_channels: 2, num_frames: 2492928}"
+///     "FloatWaveform { frame_rate_hz: 44100, num_channels: 2, num_frames: 2491776}"
 /// );
 /// println!("{:?}", &float_waveform.interleaved_samples()[30000..30005]);
 /// // [0.0238994, 0.08098572, 0.0208567, 0.09139156, 0.015145444]
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 /// let int_waveform = IntWaveform::from(float_waveform);
 /// assert_eq!(
 ///     format!("{:?}", int_waveform),
-///     "IntWaveform { frame_rate_hz: 44100, num_channels: 2, num_frames: 2492928}"
+///     "IntWaveform { frame_rate_hz: 44100, num_channels: 2, num_frames: 2491776}"
 /// );
 /// println!("{:?}", &int_waveform.interleaved_samples()[30000..30005]);
 /// // [783, 2653, 683, 2994, 496]

--- a/src/backend/sample_rescaling.rs
+++ b/src/backend/sample_rescaling.rs
@@ -6,6 +6,7 @@ pub fn i16_to_f32(s: i16) -> f32 {
 }
 
 /// Scales all 32-bit integer values to 32-bit floating point values between -1.0 and 1.0.
+#[allow(dead_code)] // Remove this once we have a function using it.
 pub fn i32_to_f32(s: i32) -> f32 {
     (s as f32) / (0x7FFFFFFF as f32)
 }

--- a/src/frontends/python/float_waveform.rs
+++ b/src/frontends/python/float_waveform.rs
@@ -629,7 +629,7 @@ impl FloatWaveform {
     ///     >>> print(batch[1].exception)
     ///     None
     ///     >>> batch[1].waveform
-    ///     <babycat.FloatWaveform: 5294592 frames, 2 channels, 44100 hz>
+    ///     <babycat.FloatWaveform: 5293440 frames, 2 channels, 44100 hz>
     ///
     ///     For the third file, the ``waveform`` field is ``None`` and the
     ///     ``exception`` field contains a reference to a

--- a/tests-c/test.c
+++ b/tests-c/test.c
@@ -24,7 +24,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_default_1() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 2492928);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 2491776);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 44100);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -70,7 +70,7 @@ test_float_waveform_from_file__test_circus_of_freaks_get_channels_1() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 1);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 2492928);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 2491776);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 44100);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -84,7 +84,7 @@ test_float_waveform_from_file__test_circus_of_freaks_get_channels_2() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 2492928);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 2491776);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 44100);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -108,7 +108,7 @@ test_float_waveform_from_file__test_circus_of_freaks_convert_to_mono_1() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 1);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 2492928);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 2491776);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 44100);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -122,7 +122,7 @@ test_float_waveform_from_file__test_circus_of_freaks_convert_to_mono_2() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 1);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 2492928);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 2491776);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 44100);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -208,7 +208,7 @@ test_float_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_5() 
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 1169928);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 1168776);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 44100);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -392,7 +392,7 @@ test_float_waveform_from_file__test_circus_of_freaks_resample_no_change() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 2492928);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 2491776);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 44100);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -405,7 +405,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_1() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 1246464);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 1245888);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 22050);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -418,7 +418,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_2() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 623232);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 622944);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 11025);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -431,7 +431,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_3() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 4985856);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 4983552);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 88200);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -444,7 +444,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_4() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 249293);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 249178);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 4410);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -457,7 +457,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_5() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 2492872);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 2491720);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 44099);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -470,7 +470,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_6() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 2713392);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 2712138);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 48000);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -483,7 +483,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_7() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 3391739);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 3390172);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 60000);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -496,7 +496,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_8() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 4985856);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 4983552);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 88200);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -509,7 +509,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_9() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 5426783);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 5424275);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 96000);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -522,7 +522,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_10() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 11306);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 11301);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 200);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -535,7 +535,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_11() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 113058);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 113006);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 2000);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -548,7 +548,7 @@ static void test_float_waveform_from_file__test_circus_of_freaks_resample_12() {
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_FloatWaveform *waveform = waveform_result.result;
   assert(babycat_float_waveform_get_num_channels(waveform) == 2);
-  assert(babycat_float_waveform_get_num_frames(waveform) == 9780);
+  assert(babycat_float_waveform_get_num_frames(waveform) == 9775);
   assert(babycat_float_waveform_get_frame_rate_hz(waveform) == 173);
   babycat_float_waveform_free(waveform);
   SUCCESS();
@@ -608,7 +608,7 @@ test_float_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_resa
 static void
 test_float_waveform_resample_method__test_circus_of_freaks_no_change_1() {
   uint32_t new_frame_rate_hz = 44100;
-  uint32_t expected_num_frames = 2492928;
+  uint32_t expected_num_frames = 2491776;
   //
   // Decode the waveform the first time.
   babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
@@ -644,7 +644,7 @@ test_float_waveform_resample_method__test_circus_of_freaks_no_change_1() {
 
 static void test_float_waveform_resample_method__test_circus_of_freaks_44099() {
   uint32_t new_frame_rate_hz = 44099;
-  uint32_t expected_num_frames = 2492872;
+  uint32_t expected_num_frames = 2491720;
   //
   // Decode the waveform the first time.
   babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
@@ -680,7 +680,7 @@ static void test_float_waveform_resample_method__test_circus_of_freaks_44099() {
 
 static void test_float_waveform_resample_method__test_circus_of_freaks_44101() {
   uint32_t new_frame_rate_hz = 44101;
-  uint32_t expected_num_frames = 2492985;
+  uint32_t expected_num_frames = 2491833;
   //
   // Decode the waveform the first time.
   babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
@@ -716,7 +716,7 @@ static void test_float_waveform_resample_method__test_circus_of_freaks_44101() {
 
 static void test_float_waveform_resample_method__test_circus_of_freaks_22050() {
   uint32_t new_frame_rate_hz = 22050;
-  uint32_t expected_num_frames = 1246464;
+  uint32_t expected_num_frames = 1245888;
   //
   // Decode the waveform the first time.
   babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
@@ -752,7 +752,7 @@ static void test_float_waveform_resample_method__test_circus_of_freaks_22050() {
 
 static void test_float_waveform_resample_method__test_circus_of_freaks_11025() {
   uint32_t new_frame_rate_hz = 11025;
-  uint32_t expected_num_frames = 623232;
+  uint32_t expected_num_frames = 622944;
   //
   // Decode the waveform the first time.
   babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
@@ -788,7 +788,7 @@ static void test_float_waveform_resample_method__test_circus_of_freaks_11025() {
 
 static void test_float_waveform_resample_method__test_circus_of_freaks_88200() {
   uint32_t new_frame_rate_hz = 88200;
-  uint32_t expected_num_frames = 4985856;
+  uint32_t expected_num_frames = 4983552;
   //
   // Decode the waveform the first time.
   babycat_DecodeArgs decode_args = babycat_decode_args_init_default();

--- a/tests-python/fixtures.py
+++ b/tests-python/fixtures.py
@@ -10,22 +10,22 @@ AT_FRAME_RATE_HZ = 44100
 
 BT_FILENAME = "./audio-for-tests/blippy-trance/track.mp3"
 BT_NUM_CHANNELS = 2
-BT_NUM_FRAMES = 5294592
+BT_NUM_FRAMES = 5293440
 BT_FRAME_RATE_HZ = 44100
 
 COF_FILENAME = "./audio-for-tests/circus-of-freaks/track.mp3"
 COF_NUM_CHANNELS = 2
-COF_NUM_FRAMES = 2492928
+COF_NUM_FRAMES = 2491776
 COF_FRAME_RATE_HZ = 44100
 
 LCT_FILENAME = "./audio-for-tests/left-channel-tone/track.mp3"
 LCT_NUM_CHANNELS = 2
-LCT_NUM_FRAMES = 1325952
+LCT_NUM_FRAMES = 1324800
 LCT_FRAME_RATE_HZ = 44100
 
 MONO_DTMF_FILENAME = "./audio-for-tests/mono-dtmf-tones/track.mp3"
 MONO_DTMF_NUM_CHANNELS = 1
-MONO_DTMF_NUM_FRAMES = 443520
+MONO_DTMF_NUM_FRAMES = 442368
 MONO_DTMF_FRAME_RATE_HZ = 44100
 
 OHFY_FILENAME = "./audio-for-tests/on-hold-for-you/track.mp3"
@@ -35,7 +35,7 @@ OHFY_FRAME_RATE_HZ = 44100
 
 TMS_FILENAME = "./audio-for-tests/tone-missing-sounds/track.mp3"
 TMS_NUM_CHANNELS = 1
-TMS_NUM_FRAMES = 1325952
+TMS_NUM_FRAMES = 1324800
 TMS_FRAME_RATE_HZ = 44100
 
 VR_FILENAME = "./audio-for-tests/voxel-revolution/track.mp3"

--- a/tests-python/test_float_waveform_from_file.py
+++ b/tests-python/test_float_waveform_from_file.py
@@ -156,7 +156,7 @@ def test_circus_of_freaks_start_end_milliseconds_5():
         end_time_milliseconds=60000,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 1169928
+    assert waveform.num_frames == 1168776
     assert waveform.frame_rate_hz == COF_FRAME_RATE_HZ
 
 
@@ -297,7 +297,7 @@ def test_circus_of_freaks_resample_1():
         frame_rate_hz=22050,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 1246464
+    assert waveform.num_frames == 1245888
     assert waveform.frame_rate_hz == 22050
 
 
@@ -307,7 +307,7 @@ def test_circus_of_freaks_resample_2():
         frame_rate_hz=11025,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 623232
+    assert waveform.num_frames == 622944
     assert waveform.frame_rate_hz == 11025
 
 
@@ -317,7 +317,7 @@ def test_circus_of_freaks_resample_3():
         frame_rate_hz=88200,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 4985856
+    assert waveform.num_frames == 4983552
     assert waveform.frame_rate_hz == 88200
 
 
@@ -327,7 +327,7 @@ def test_circus_of_freaks_resample_4():
         frame_rate_hz=4410,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 249293
+    assert waveform.num_frames == 249178
     assert waveform.frame_rate_hz == 4410
 
 
@@ -337,7 +337,7 @@ def test_circus_of_freaks_resample_5():
         frame_rate_hz=44099,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 2492872
+    assert waveform.num_frames == 2491720
     assert waveform.frame_rate_hz == 44099
 
 
@@ -347,7 +347,7 @@ def test_circus_of_freaks_resample_6():
         frame_rate_hz=48000,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 2713392
+    assert waveform.num_frames == 2712138
     assert waveform.frame_rate_hz == 48000
 
 
@@ -357,7 +357,7 @@ def test_circus_of_freaks_resample_7():
         frame_rate_hz=60000,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 3391739
+    assert waveform.num_frames == 3390172
     assert waveform.frame_rate_hz == 60000
 
 
@@ -367,7 +367,7 @@ def test_circus_of_freaks_resample_8():
         frame_rate_hz=88200,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 4985856
+    assert waveform.num_frames == 4983552
     assert waveform.frame_rate_hz == 88200
 
 
@@ -377,7 +377,7 @@ def test_circus_of_freaks_resample_9():
         frame_rate_hz=96000,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 5426783
+    assert waveform.num_frames == 5424275
     assert waveform.frame_rate_hz == 96000
 
 
@@ -387,7 +387,7 @@ def test_circus_of_freaks_resample_10():
         frame_rate_hz=200,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 11306
+    assert waveform.num_frames == 11301
     assert waveform.frame_rate_hz == 200
 
 
@@ -397,7 +397,7 @@ def test_circus_of_freaks_resample_11():
         frame_rate_hz=2000,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 113058
+    assert waveform.num_frames == 113006
     assert waveform.frame_rate_hz == 2000
 
 
@@ -407,7 +407,7 @@ def test_circus_of_freaks_resample_12():
         frame_rate_hz=173,
     )
     assert waveform.num_channels == COF_NUM_CHANNELS
-    assert waveform.num_frames == 9780
+    assert waveform.num_frames == 9775
     assert waveform.frame_rate_hz == 173
 
 

--- a/tests-python/test_float_waveform_resample_method.py
+++ b/tests-python/test_float_waveform_resample_method.py
@@ -57,7 +57,7 @@ def test_circus_of_freaks_44099():
         decode_args={},
         frame_rate_hz=44099,
         expected_num_channels=COF_NUM_CHANNELS,
-        expected_num_frames=2492872,
+        expected_num_frames=2491720,
         expected_frame_rate_hz=44099,
     )
 
@@ -68,7 +68,7 @@ def test_circus_of_freaks_44101():
         decode_args={},
         frame_rate_hz=44101,
         expected_num_channels=COF_NUM_CHANNELS,
-        expected_num_frames=2492985,
+        expected_num_frames=2491833,
         expected_frame_rate_hz=44101,
     )
 

--- a/tests-wasm-nodejs/test.js
+++ b/tests-wasm-nodejs/test.js
@@ -11,7 +11,7 @@ const COF_FILENAME = path.join(
 );
 
 const COF = fs.readFileSync(COF_FILENAME);
-const COF_NUM_FRAMES = 2492928;
+const COF_NUM_FRAMES = 2491776;
 const COF_NUM_CHANNELS = 2;
 const COF_FRAME_RATE_HZ = 44100;
 
@@ -178,7 +178,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       end_time_milliseconds: 60000,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 1169928, COF_FRAME_RATE_HZ);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 1168776, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_1", function () {
@@ -317,7 +317,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 22050,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 1246464, 22050);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 1245888, 22050);
   });
 
   it("test_circus_of_freaks_resample_2", function () {
@@ -325,7 +325,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 11025,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 623232, 11025);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 622944, 11025);
   });
 
   it("test_circus_of_freaks_resample_3", function () {
@@ -333,7 +333,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 88200,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 4985856, 88200);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 4983552, 88200);
   });
 
   it("test_circus_of_freaks_resample_4", function () {
@@ -341,7 +341,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 4410,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 249293, 4410);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 249178, 4410);
   });
 
   it("test_circus_of_freaks_resample_5", function () {
@@ -349,7 +349,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 44099,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 2492872, 44099);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 2491720, 44099);
   });
 
   it("test_circus_of_freaks_resample_6", function () {
@@ -357,7 +357,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 48000,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 2713392, 48000);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 2712138, 48000);
   });
 
   it("test_circus_of_freaks_resample_7", function () {
@@ -365,7 +365,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 60000,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 3391739, 60000);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 3390172, 60000);
   });
 
   it("test_circus_of_freaks_resample_8", function () {
@@ -373,7 +373,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 88200,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 4985856, 88200);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 4983552, 88200);
   });
 
   it("test_circus_of_freaks_resample_9", function () {
@@ -381,7 +381,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 96000,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 5426783, 96000);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 5424275, 96000);
   });
 
   it("test_circus_of_freaks_resample_10", function () {
@@ -389,7 +389,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 200,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 11306, 200);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 11301, 200);
   });
 
   it("test_circus_of_freaks_resample_11", function () {
@@ -397,7 +397,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 2000,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 113058, 2000);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 113006, 2000);
   });
 
   it("test_circus_of_freaks_resample_12", function () {
@@ -405,7 +405,7 @@ describe("FloatWaveform.fromEncodedArray", function () {
       frame_rate_hz: 173,
     };
     const waveform = babycat.FloatWaveform.fromEncodedArray(COF, decodeArgs);
-    assertWaveform(waveform, COF_NUM_CHANNELS, 9780, 173);
+    assertWaveform(waveform, COF_NUM_CHANNELS, 9775, 173);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_1", function () {
@@ -453,15 +453,15 @@ describe("FloatWaveform.resampleByMode", function () {
   }
 
   it("test_circus_of_freaks_no_change_1", function () {
-    decodeAndAssertCOF(44100, 2492928);
+    decodeAndAssertCOF(44100, 2491776);
   });
 
   it("test_circus_of_freaks_44099", function () {
-    decodeAndAssertCOF(44099, 2492872);
+    decodeAndAssertCOF(44099, 2491720);
   });
 
   it("test_circus_of_freaks_44101", function () {
-    decodeAndAssertCOF(44101, 2492985);
+    decodeAndAssertCOF(44101, 2491833);
   });
 
   it("test_circus_of_freaks_22050", function () {

--- a/tests/fixtures.rs
+++ b/tests/fixtures.rs
@@ -7,22 +7,22 @@ pub const AT_FRAME_RATE_HZ: u32 = 44100;
 
 pub const BT_FILENAME: &str = "./audio-for-tests/blippy-trance/track.mp3";
 pub const BT_NUM_CHANNELS: u32 = 2;
-pub const BT_NUM_FRAMES: u64 = 5294592;
+pub const BT_NUM_FRAMES: u64 = 5293440;
 pub const BT_FRAME_RATE_HZ: u32 = 44100;
 
 pub const COF_FILENAME: &str = "./audio-for-tests/circus-of-freaks/track.mp3";
 pub const COF_NUM_CHANNELS: u32 = 2;
-pub const COF_NUM_FRAMES: u64 = 2492928;
+pub const COF_NUM_FRAMES: u64 = 2491776;
 pub const COF_FRAME_RATE_HZ: u32 = 44100;
 
 pub const LCT_FILENAME: &str = "./audio-for-tests/left-channel-tone/track.mp3";
 pub const LCT_NUM_CHANNELS: u32 = 2;
-pub const LCT_NUM_FRAMES: u64 = 1325952;
+pub const LCT_NUM_FRAMES: u64 = 1324800;
 pub const LCT_FRAME_RATE_HZ: u32 = 44100;
 
 pub const MONO_DTMF_FILENAME: &str = "./audio-for-tests/mono-dtmf-tones/track.mp3";
 pub const MONO_DTMF_NUM_CHANNELS: u32 = 1;
-pub const MONO_DTMF_NUM_FRAMES: u64 = 443520;
+pub const MONO_DTMF_NUM_FRAMES: u64 = 442368;
 pub const MONO_DTMF_FRAME_RATE_HZ: u32 = 44100;
 
 pub const OHFY_FILENAME: &str = "./audio-for-tests/on-hold-for-you/track.mp3";
@@ -32,7 +32,7 @@ pub const OHFY_FRAME_RATE_HZ: u32 = 44100;
 
 pub const TMS_FILENAME: &str = "./audio-for-tests/tone-missing-sounds/track.mp3";
 pub const TMS_NUM_CHANNELS: u32 = 1;
-pub const TMS_NUM_FRAMES: u64 = 1325952;
+pub const TMS_NUM_FRAMES: u64 = 1324800;
 pub const TMS_FRAME_RATE_HZ: u32 = 44100;
 
 pub const VR_FILENAME: &str = "./audio-for-tests/voxel-revolution/track.mp3";

--- a/tests/test_float_waveform_from_file.rs
+++ b/tests/test_float_waveform_from_file.rs
@@ -226,7 +226,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 1169928, COF_FRAME_RATE_HZ);
+        assert_waveform(result, COF_NUM_CHANNELS, 1168776, COF_FRAME_RATE_HZ);
     }
 
     #[test]
@@ -383,7 +383,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 1246464, 22050);
+        assert_waveform(result, COF_NUM_CHANNELS, 1245888, 22050);
     }
 
     #[test]
@@ -393,7 +393,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 623232, 11025);
+        assert_waveform(result, COF_NUM_CHANNELS, 622944, 11025);
     }
 
     #[test]
@@ -403,7 +403,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 4985856, 88200);
+        assert_waveform(result, COF_NUM_CHANNELS, 4983552, 88200);
     }
 
     #[test]
@@ -413,7 +413,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 249293, 4410);
+        assert_waveform(result, COF_NUM_CHANNELS, 249178, 4410);
     }
 
     #[test]
@@ -423,7 +423,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 2492872, 44099);
+        assert_waveform(result, COF_NUM_CHANNELS, 2491720, 44099);
     }
 
     #[test]
@@ -433,7 +433,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 2713392, 48000);
+        assert_waveform(result, COF_NUM_CHANNELS, 2712138, 48000);
     }
 
     #[test]
@@ -443,7 +443,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 3391739, 60000);
+        assert_waveform(result, COF_NUM_CHANNELS, 3390172, 60000);
     }
 
     #[test]
@@ -453,7 +453,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 4985856, 88200);
+        assert_waveform(result, COF_NUM_CHANNELS, 4983552, 88200);
     }
 
     #[test]
@@ -463,7 +463,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 5426783, 96000);
+        assert_waveform(result, COF_NUM_CHANNELS, 5424275, 96000);
     }
 
     #[test]
@@ -473,7 +473,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 11306, 200);
+        assert_waveform(result, COF_NUM_CHANNELS, 11301, 200);
     }
 
     #[test]
@@ -483,7 +483,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 113058, 2000);
+        assert_waveform(result, COF_NUM_CHANNELS, 113006, 2000);
     }
 
     #[test]
@@ -493,7 +493,7 @@ mod test_float_waveform_from_file {
             ..Default::default()
         };
         let result = decode_cof_mp3(decode_args);
-        assert_waveform(result, COF_NUM_CHANNELS, 9780, 173);
+        assert_waveform(result, COF_NUM_CHANNELS, 9775, 173);
     }
 
     #[test]

--- a/tests/test_float_waveform_resample_method.rs
+++ b/tests/test_float_waveform_resample_method.rs
@@ -87,7 +87,7 @@ mod test_float_waveform_resample_method {
             Default::default(),
             44099,
             COF_NUM_CHANNELS,
-            2492872,
+            2491720,
             44099,
         );
     }
@@ -100,7 +100,7 @@ mod test_float_waveform_resample_method {
             Default::default(),
             44101,
             COF_NUM_CHANNELS,
-            2492985,
+            2491833,
             44101,
         );
     }


### PR DESCRIPTION
Previously, the Symphonia audio library included an
MPEG frame (1152 frames) of silence at the beginning of every
decoded MP3.

Recent updates to Symphonia have removed this issue, so
we in Babycat are pinning the newer Symphonia and updating
our unit tests to no longer expect those extra 1152 frames.