### PR TITLE
Allow loading decoded waveforms from NumPy arrays and lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # These are the Rust files being tracked by Git.
 RUST_SRC_FILES ?= $(shell git ls-files --cached --deleted --modified --others src)
 
+# These are the documentation files tracked by Git.
+DOCS_FILES ?= $(shell git ls-files --cached --deleted --modified --others docs)
+
 
 # These variables set the path for Rust or system tools.
 CBINDGEN ?= cbindgen
@@ -419,7 +422,7 @@ build-binary: target/frontend-binary/release/$(BABYCAT_BINARY_NAME)
 # ===================================================================
 
 ## docs
-.b/docs: .b/init-javascript-tools .b/install-python-wheel target/frontend-wasm/release/bundler/babycat_bg.wasm babycat.h
+.b/docs: .b/init-javascript-tools .b/install-python-wheel target/frontend-wasm/release/bundler/babycat_bg.wasm babycat.h $(DOCS_FILES)
 	rm -rf docs/build
 	mkdir docs/build
 	$(DOXYGEN)

--- a/docs/source/api/c/babycat_FloatWaveform/babycat_float_waveform_get_interleaved_samples.rst
+++ b/docs/source/api/c/babycat_FloatWaveform/babycat_float_waveform_get_interleaved_samples.rst
@@ -1,4 +1,0 @@
-babycat_float_waveform_get_interleaved_samples()
-================================================
-
-.. doxygenfunction:: babycat_float_waveform_get_interleaved_samples

--- a/docs/source/api/c/babycat_FloatWaveform/babycat_float_waveform_to_interleaved_samples.rst
+++ b/docs/source/api/c/babycat_FloatWaveform/babycat_float_waveform_to_interleaved_samples.rst
@@ -1,0 +1,4 @@
+babycat_float_waveform_to_interleaved_samples()
+================================================
+
+.. doxygenfunction:: babycat_float_waveform_to_interleaved_samples

--- a/docs/source/api/c/babycat_FloatWaveform/index.rst
+++ b/docs/source/api/c/babycat_FloatWaveform/index.rst
@@ -10,13 +10,14 @@ babycat_FloatWaveform
    babycat_float_waveform_get_num_channels
    babycat_float_waveform_get_num_frames
    babycat_float_waveform_get_num_samples
-   babycat_float_waveform_get_interleaved_samples
+   babycat_float_waveform_to_interleaved_samples
    babycat_float_waveform_from_frames_of_silence
    babycat_float_waveform_from_milliseconds_of_silence
    babycat_float_waveform_from_encoded_bytes
    babycat_float_waveform_from_file
    babycat_float_waveform_resample
    babycat_float_waveform_resample_by_mode
+
 
 Typedef members
 ---------------
@@ -34,7 +35,7 @@ Waveform properties
 - :doc:`babycat_float_waveform_get_num_channels`
 - :doc:`babycat_float_waveform_get_num_frames`
 - :doc:`babycat_float_waveform_get_num_samples`
-- :doc:`babycat_float_waveform_get_interleaved_samples`
+
 
 Generating waveform from silence
 --------------------------------
@@ -46,6 +47,11 @@ Decoding audio
 --------------
 - :doc:`babycat_float_waveform_from_encoded_bytes`
 - :doc:`babycat_float_waveform_from_file`
+
+
+Exporting decoded audio
+-----------------------
+- :doc:`babycat_float_waveform_to_interleaved_samples`
 
 
 Resampling audio

--- a/docs/source/api/python/FloatWaveform/from_interleaved_samples.rst
+++ b/docs/source/api/python/FloatWaveform/from_interleaved_samples.rst
@@ -1,0 +1,4 @@
+FloatWaveform.from_interleaved_samples()
+========================================
+
+.. automethod:: babycat.FloatWaveform.from_interleaved_samples

--- a/docs/source/api/python/FloatWaveform/from_numpy.rst
+++ b/docs/source/api/python/FloatWaveform/from_numpy.rst
@@ -1,0 +1,4 @@
+FloatWaveform.from_numpy()
+==========================
+
+.. automethod:: babycat.FloatWaveform.from_numpy

--- a/docs/source/api/python/FloatWaveform/index.rst
+++ b/docs/source/api/python/FloatWaveform/index.rst
@@ -3,6 +3,7 @@ babycat.FloatWaveform
 
 .. py:class:: babycat.FloatWaveform
 
+
 Waveform properties
 -------------------
 .. toctree::
@@ -13,13 +14,22 @@ Waveform properties
    .num_frames <num_frames>
 
 
-Generating waveform from silence
---------------------------------
+Generating waveforms from silence
+---------------------------------
 .. toctree::
    :maxdepth: 2
 
    .from_frames_of_silence() <from_frames_of_silence>
    .from_milliseconds_of_silence() <from_milliseconds_of_silence>
+
+
+Importing already-decoded audio waveforms
+-----------------------------------------
+.. toctree::
+   :maxdepth: 2
+
+   .from_interleaved_samples() <from_interleaved_samples>
+   .from_numpy() <from_numpy>
 
 
 Decoding audio
@@ -41,12 +51,20 @@ Resampling audio
    .resample_by_mode() <resample_by_mode>
 
 
+Exporting decoded audio
+-----------------------
+.. toctree::
+   :maxdepth: 2
+
+   .to_interleaved_samples() <to_interleaved_samples>
+   .to_numpy() <to_numpy>
+
+
 Encoding audio
 --------------
 .. toctree::
    :maxdepth: 2
 
+
    .to_wav_buffer() <to_wav_buffer>
    .to_wav_file() <to_wav_file>
-   .numpy() <numpy>
-

--- a/docs/source/api/python/FloatWaveform/numpy.rst
+++ b/docs/source/api/python/FloatWaveform/numpy.rst
@@ -1,4 +1,0 @@
-FloatWaveform.numpy()
-=====================
-
-.. automethod:: babycat.FloatWaveform.numpy

--- a/docs/source/api/python/FloatWaveform/to_interleaved_samples.rst
+++ b/docs/source/api/python/FloatWaveform/to_interleaved_samples.rst
@@ -1,0 +1,4 @@
+FloatWaveform.to_interleaved_samples()
+======================================
+
+.. automethod:: babycat.FloatWaveform.to_interleaved_samples

--- a/docs/source/api/python/FloatWaveform/to_numpy.rst
+++ b/docs/source/api/python/FloatWaveform/to_numpy.rst
@@ -1,0 +1,4 @@
+FloatWaveform.to_numpy()
+========================
+
+.. automethod:: babycat.FloatWaveform.to_numpy

--- a/docs/source/api/wasm/FloatWaveform/index.rst
+++ b/docs/source/api/wasm/FloatWaveform/index.rst
@@ -8,39 +8,48 @@ babycat.FloatWaveform
    .frameRateHz() <frameRateHz>
    .numChannels() <numChannels>
    .numFrames() <numFrames>
-   .interleavedSamples() <interleavedSamples>
    .fromFramesOfSilence() <fromFramesOfSilence>
    .fromMillisecondsOfSilence() <fromMillisecondsOfSilence>
    .fromEncodedArray() <fromEncodedArray>
    .fromEncodedArrayWithHint() <fromEncodedArrayWithHint>
    .resample() <resample>
    .resampleByMode() <resampleByMode>
+   .toInterleavedSamples() <toInterleavedSamples>
    .toWavBuffer() <toWavBuffer>
 
 
 .. js:class:: babycat.FloatWaveform
+
 
 Waveform properties
 -------------------
 - :doc:`frameRateHz`
 - :doc:`numChannels`
 - :doc:`numFrames`
-- :doc:`interleavedSamples`
+
 
 Generating waveform from silence
 --------------------------------
 - :doc:`fromFramesOfSilence`
 - :doc:`fromMillisecondsOfSilence`
 
+
 Decoding audio
 --------------
 - :doc:`fromEncodedArray`
 - :doc:`fromEncodedArrayWithHint`
 
+
 Resampling audio
 ----------------
 - :doc:`resample`
 - :doc:`resampleByMode`
+
+
+Exporting decoded audio
+-----------------------
+- :doc:`toInterleavedSamples`
+
 
 Encoding audio
 --------------

--- a/docs/source/api/wasm/FloatWaveform/interleavedSamples.rst
+++ b/docs/source/api/wasm/FloatWaveform/interleavedSamples.rst
@@ -1,4 +1,0 @@
-FloatWaveform.interleavedSamples()
-==================================
-
-.. js:autofunction:: interleavedSamples

--- a/docs/source/api/wasm/FloatWaveform/toInterleavedSamples.rst
+++ b/docs/source/api/wasm/FloatWaveform/toInterleavedSamples.rst
@@ -1,0 +1,4 @@
+FloatWaveform.toInterleavedSamples()
+====================================
+
+.. js:autofunction:: toInterleavedSamples

--- a/examples/resampler_comparison.rs
+++ b/examples/resampler_comparison.rs
@@ -156,7 +156,7 @@ fn benchmark_left_channel_tone() {
         Default::default(),
     )
     .unwrap()
-    .interleaved_samples()
+    .to_interleaved_samples()
     .to_owned();
     benchmark_all_funcs("left_channel_tone_1", 44100, 4410, 2, &left_channel_tone);
     benchmark_all_funcs("left_channel_tone_2", 44100, 11025, 2, &left_channel_tone);
@@ -175,7 +175,7 @@ fn benchmark_blippy_trance() {
         Default::default(),
     )
     .unwrap()
-    .interleaved_samples()
+    .to_interleaved_samples()
     .to_owned();
     benchmark_all_funcs("blippy_trance_1", 44100, 4410, 2, &blippy_trance);
     benchmark_all_funcs("blippy_trance_2", 44100, 11025, 2, &blippy_trance);
@@ -194,7 +194,7 @@ fn benchmark_on_hold_for_you() {
         Default::default(),
     )
     .unwrap()
-    .interleaved_samples()
+    .to_interleaved_samples()
     .to_owned();
     benchmark_all_funcs("on_hold_for_you_1", 44100, 4410, 2, &on_hold_for_you);
     benchmark_all_funcs("on_hold_for_you_2", 44100, 11025, 2, &on_hold_for_you);

--- a/src/backend/float_waveform.rs
+++ b/src/backend/float_waveform.rs
@@ -31,7 +31,7 @@ pub struct FloatWaveform {
 impl From<crate::backend::int_waveform::IntWaveform> for FloatWaveform {
     fn from(item: crate::backend::int_waveform::IntWaveform) -> Self {
         let buffer: Vec<f32> = item
-            .interleaved_samples()
+            .to_interleaved_samples()
             .iter()
             .map(|val| i16_to_f32(*val))
             .collect();
@@ -60,6 +60,14 @@ impl fmt::Debug for FloatWaveform {
 }
 
 impl FloatWaveform {
+    ///
+    pub fn from_interleaved_samples(
+        frame_rate_hz: u32,
+        num_channels: u32,
+        interleaved_samples: &[f32],
+    ) -> Self {
+        Self::new(frame_rate_hz, num_channels, interleaved_samples.to_owned())
+    }
     /// Decodes audio stored in an in-memory byte array.
     ///
     /// # Arguments
@@ -346,7 +354,7 @@ impl FloatWaveform {
             return Err(Error::WrongNumChannelsAndMono);
         }
 
-        /// Initialize our audio decoding backend.
+        // Initialize our audio decoding backend.
         let mut decoder = match decode_args.decoding_backend {
             DEFAULT_DECODING_BACKEND | DECODING_BACKEND_SYMPHONIA => {
                 SymphoniaDecoder::new(encoded_stream, file_extension, mime_type)?
@@ -757,7 +765,7 @@ impl crate::backend::waveform::Waveform<f32> for FloatWaveform {
     }
 
     /// Returns the waveform as a slice of channel-interleaved `f32` samples.
-    fn interleaved_samples(&self) -> &[f32] {
+    fn to_interleaved_samples(&self) -> &[f32] {
         &self.interleaved_samples
     }
 }

--- a/src/backend/int_waveform.rs
+++ b/src/backend/int_waveform.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 ///     format!("{:?}", float_waveform),
 ///     "FloatWaveform { frame_rate_hz: 44100, num_channels: 2, num_frames: 2491776}"
 /// );
-/// println!("{:?}", &float_waveform.interleaved_samples()[30000..30005]);
+/// println!("{:?}", &float_waveform.to_interleaved_samples()[30000..30005]);
 /// // [0.0238994, 0.08098572, 0.0208567, 0.09139156, 0.015145444]
 ///
 ///
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 ///     format!("{:?}", int_waveform),
 ///     "IntWaveform { frame_rate_hz: 44100, num_channels: 2, num_frames: 2491776}"
 /// );
-/// println!("{:?}", &int_waveform.interleaved_samples()[30000..30005]);
+/// println!("{:?}", &int_waveform.to_interleaved_samples()[30000..30005]);
 /// // [783, 2653, 683, 2994, 496]
 /// ```
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -48,7 +48,7 @@ pub struct IntWaveform {
 impl From<crate::backend::float_waveform::FloatWaveform> for IntWaveform {
     fn from(item: crate::backend::float_waveform::FloatWaveform) -> Self {
         let buffer: Vec<i16> = item
-            .interleaved_samples()
+            .to_interleaved_samples()
             .iter()
             .map(|val| f32_to_i16(*val))
             .collect();
@@ -112,7 +112,7 @@ impl crate::backend::waveform::Waveform<i16> for IntWaveform {
     }
 
     /// Returns the waveform as a slice of channel-interleaved `i16` samples.
-    fn interleaved_samples(&self) -> &[i16] {
+    fn to_interleaved_samples(&self) -> &[i16] {
         &self.interleaved_samples
     }
 }

--- a/src/backend/waveform.rs
+++ b/src/backend/waveform.rs
@@ -19,5 +19,5 @@ pub trait Waveform<T> {
     fn num_frames(&self) -> u64;
 
     /// Return the waveform as a slice of interleaved samples.
-    fn interleaved_samples(&self) -> &[T];
+    fn to_interleaved_samples(&self) -> &[T];
 }

--- a/src/bin/babycat/commands/play.rs
+++ b/src/bin/babycat/commands/play.rs
@@ -44,7 +44,7 @@ impl From<&FloatWaveform> for FloatWaveformSource {
             num_samples,
             current_sample_idx,
             duration,
-            interleaved_samples: item.interleaved_samples().to_vec(),
+            interleaved_samples: item.to_interleaved_samples().to_vec(),
         }
     }
 }

--- a/src/frontends/c.rs
+++ b/src/frontends/c.rs
@@ -284,10 +284,10 @@ pub unsafe extern "C" fn babycat_float_waveform_get_num_samples(
 ///
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn babycat_float_waveform_get_interleaved_samples(
+pub unsafe extern "C" fn babycat_float_waveform_to_interleaved_samples(
     waveform: *mut FloatWaveform,
 ) -> *const f32 {
-    waveform.as_ref().unwrap().interleaved_samples().as_ptr()
+    waveform.as_ref().unwrap().to_interleaved_samples().as_ptr()
 }
 
 /// Resample a `babycat_FloatWaveform` with the default resampler.

--- a/src/frontends/wasm.rs
+++ b/src/frontends/wasm.rs
@@ -96,8 +96,8 @@ impl FloatWaveform {
     }
 
     /// Returns channel-interleaved samples.
-    pub fn interleavedSamples(&self) -> Float32Array {
-        Float32Array::from(self.inner.interleaved_samples())
+    pub fn toInterleavedSamples(&self) -> Float32Array {
+        Float32Array::from(self.inner.to_interleaved_samples())
     }
 
     /// Return the frame rate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 //!     match &named_result.result {
 //!         Ok(waveform) => {
 //!             // Do further processing.
-//!             waveform.interleaved_samples();
+//!             waveform.to_interleaved_samples();
 //!         }
 //!         Err(err) => {
 //!             // Handle decoding errors.

--- a/tests-python/test_float_waveform_from_interleaved_samples.py
+++ b/tests-python/test_float_waveform_from_interleaved_samples.py
@@ -1,0 +1,41 @@
+"""
+Test loading waveforms from 1-D Python lists.
+"""
+from babycat import FloatWaveform
+
+
+def test_empty():
+    waveform = FloatWaveform.from_interleaved_samples(
+        frame_rate_hz=44_100,
+        num_channels=3,
+        interleaved_samples=[],
+    )
+    assert waveform.frame_rate_hz == 44_100
+    assert waveform.num_channels == 3
+    assert waveform.to_interleaved_samples() == []
+
+
+def test_four_frames_three_channels():
+    interleaved_samples = [
+        -1.0,
+        0.0,
+        1.0,
+        #
+        -1.0,
+        0.0,
+        1.0,
+        #
+        -1.0,
+        0.0,
+        1.0,
+        #
+        -1.0,
+        0.0,
+        1.0,
+    ]
+    waveform = FloatWaveform.from_interleaved_samples(
+        frame_rate_hz=44_100,
+        num_channels=3,
+        interleaved_samples=interleaved_samples,
+    )
+    assert interleaved_samples == waveform.to_interleaved_samples()

--- a/tests-python/test_float_waveform_from_numpy.py
+++ b/tests-python/test_float_waveform_from_numpy.py
@@ -1,0 +1,81 @@
+"""
+Test loading waveforms from NumPy arrays.
+"""
+import numpy as np
+import pytest
+from fixtures import COF_FILENAME, COF_FRAME_RATE_HZ, COF_NUM_CHANNELS, COF_NUM_FRAMES
+
+from babycat import FloatWaveform
+
+
+def test_circus_of_freaks_default_1():
+    w1 = FloatWaveform.from_file(COF_FILENAME)
+    waveform = FloatWaveform.from_numpy(
+        frame_rate_hz=w1.frame_rate_hz,
+        arr=w1.to_numpy(),
+    )
+    assert waveform.num_channels == COF_NUM_CHANNELS
+    assert waveform.num_frames == COF_NUM_FRAMES
+    assert waveform.frame_rate_hz == COF_FRAME_RATE_HZ
+    np.testing.assert_array_equal(w1.to_numpy(), waveform.to_numpy())
+
+
+def test_four_frames_three_channels():
+    frame = np.array([-1.0, 0.0, 1.0], dtype="float32")
+    arr = np.stack([frame, frame, frame, frame])
+    waveform = FloatWaveform.from_numpy(
+        frame_rate_hz=44_100,
+        arr=arr,
+    )
+    assert waveform.num_channels == 3
+    assert waveform.num_frames == 4
+    assert waveform.frame_rate_hz == 44_100
+    np.testing.assert_array_equal(arr, waveform.to_numpy())
+
+
+def test_wrong_dtype_1():
+    """Raise a TypeError when we pass a float64 array."""
+    frame = np.array([-1.0, 0.0, 1.0], dtype="float64")
+    arr = np.stack([frame, frame, frame])
+    with pytest.raises(TypeError):
+        FloatWaveform.from_numpy(
+            frame_rate_hz=44_100,
+            arr=arr,
+        )
+
+
+def test_wrong_dtype_2():
+    """Raise a TypeError when we pass an integer array."""
+    frame = np.array([-1, 0, 1], dtype="int64")
+    arr = np.stack([frame, frame, frame])
+    with pytest.raises(TypeError):
+        FloatWaveform.from_numpy(
+            frame_rate_hz=44_100,
+            arr=arr,
+        )
+
+
+def test_wrong_shape_1():
+    """Raise a TypeError when we pass a 1D NumPy array."""
+    arr = np.array([-1.0, 0.0, 1.0, -1.0, 0.0, 1.0], dtype="float32")
+    with pytest.raises(TypeError):
+        FloatWaveform.from_numpy(frame_rate_hz=44_100, arr=arr)
+
+
+def test_wrong_shape_2():
+    """Raise a TypeError when we pass a 3D NumPy array."""
+    arr = np.array(
+        [
+            [
+                [-1.0, 1.0],
+                [-1.0, 1.0],
+            ],
+            [
+                [-1.0, 1.0],
+                [-1.0, 1.0],
+            ],
+        ],
+        dtype="float32",
+    )
+    with pytest.raises(TypeError):
+        FloatWaveform.from_numpy(frame_rate_hz=44_100, arr=arr)

--- a/tests/test_float_waveform_from_file.rs
+++ b/tests/test_float_waveform_from_file.rs
@@ -31,7 +31,7 @@ mod test_float_waveform_from_file {
         assert_eq!(frame_rate_hz, waveform.frame_rate_hz());
         assert_eq!(
             (num_frames * num_channels as u64) as usize,
-            waveform.interleaved_samples().len()
+            waveform.to_interleaved_samples().len()
         );
     }
 
@@ -142,7 +142,7 @@ mod test_float_waveform_from_file {
         assert_eq!(1, mono_waveform.num_channels());
         assert_eq!(LCT_NUM_FRAMES, mono_waveform.num_frames());
         assert_eq!(LCT_FRAME_RATE_HZ, mono_waveform.frame_rate_hz());
-        let mono_sum_waveform: f32 = mono_waveform.interleaved_samples().iter().sum();
+        let mono_sum_waveform: f32 = mono_waveform.to_interleaved_samples().iter().sum();
         // Now, let's do the stereo decoding.
         let stereo_decode_args = DecodeArgs {
             ..Default::default()
@@ -152,7 +152,7 @@ mod test_float_waveform_from_file {
         assert_eq!(LCT_NUM_CHANNELS, stereo_waveform.num_channels());
         assert_eq!(LCT_NUM_FRAMES, stereo_waveform.num_frames());
         assert_eq!(LCT_FRAME_RATE_HZ, stereo_waveform.frame_rate_hz());
-        let stereo_sum_waveform: f32 = stereo_waveform.interleaved_samples().iter().sum();
+        let stereo_sum_waveform: f32 = stereo_waveform.to_interleaved_samples().iter().sum();
         // Check that the mono waveform is quieter because we made it
         // by averaging in the other silent channel.
         assert!(float_cmp::approx_eq!(

--- a/tests/test_float_waveform_from_interleaved_samples.rs
+++ b/tests/test_float_waveform_from_interleaved_samples.rs
@@ -1,0 +1,18 @@
+mod test_float_waveform_from_interleaved_samples {
+    use babycat::FloatWaveform;
+    use babycat::Waveform;
+
+    #[test]
+    fn test_four_frames_three_channels() {
+        let interleaved_samples: Vec<f32> = vec![
+            -1.0, 0.0, 1.0, //
+            -1.0, 0.0, 1.0, //
+            -1.0, 0.0, 1.0, //
+            -1.0, 0.0, 1.0,
+        ];
+        let waveform = FloatWaveform::from_interleaved_samples(44100, 3, &interleaved_samples);
+        assert_eq!(waveform.num_channels(), 3);
+        assert_eq!(waveform.num_frames(), 4);
+        assert_eq!(waveform.frame_rate_hz(), 44100);
+    }
+}

--- a/tests/test_float_waveform_from_many_files.rs
+++ b/tests/test_float_waveform_from_many_files.rs
@@ -17,7 +17,7 @@ mod test_float_waveform_from_many_files {
             assert_eq!(COF_FRAME_RATE_HZ, waveform.frame_rate_hz());
             assert_eq!(
                 (COF_NUM_FRAMES * COF_NUM_CHANNELS as u64) as usize,
-                waveform.interleaved_samples().len()
+                waveform.to_interleaved_samples().len()
             );
         }
     }
@@ -39,7 +39,7 @@ mod test_float_waveform_from_many_files {
             assert_eq!(COF_FRAME_RATE_HZ, waveform.frame_rate_hz());
             assert_eq!(
                 (num_frames * COF_NUM_CHANNELS as u64) as usize,
-                waveform.interleaved_samples().len()
+                waveform.to_interleaved_samples().len()
             );
         }
     }
@@ -60,7 +60,7 @@ mod test_float_waveform_from_many_files {
             assert_eq!(COF_FRAME_RATE_HZ, waveform.frame_rate_hz());
             assert_eq!(
                 (COF_NUM_FRAMES * COF_NUM_CHANNELS as u64) as usize,
-                waveform.interleaved_samples().len()
+                waveform.to_interleaved_samples().len()
             );
         }
     }
@@ -77,7 +77,7 @@ mod test_float_waveform_from_many_files {
             assert_eq!(ALL_FRAME_RATE_HZ[i], waveform.frame_rate_hz());
             assert_eq!(
                 (ALL_NUM_FRAMES[i] * ALL_NUM_CHANNELS[i] as u64) as usize,
-                waveform.interleaved_samples().len()
+                waveform.to_interleaved_samples().len()
             );
         }
     }

--- a/tests/test_int_waveform.rs
+++ b/tests/test_int_waveform.rs
@@ -13,7 +13,7 @@ mod test_int_waveform {
         assert_eq!(int_waveform_1.num_frames(), 0x8000);
         assert_eq!(int_waveform_1.num_channels(), 2);
         assert_eq!(int_waveform_1.frame_rate_hz(), 44100);
-        assert_eq!(int_waveform_1.interleaved_samples(), int_samples);
+        assert_eq!(int_waveform_1.to_interleaved_samples(), int_samples);
         // Convert it to a FloatWaveform.
         let float_waveform = FloatWaveform::from(int_waveform_1.clone());
         assert_eq!(float_waveform.num_frames(), 0x8000);
@@ -25,7 +25,7 @@ mod test_int_waveform {
         assert_eq!(int_waveform_2.num_frames(), 0x8000);
         assert_eq!(int_waveform_2.num_channels(), 2);
         assert_eq!(int_waveform_2.frame_rate_hz(), 44100);
-        assert_eq!(int_waveform_2.interleaved_samples(), int_samples);
+        assert_eq!(int_waveform_2.to_interleaved_samples(), int_samples);
     }
 
     #[test]


### PR DESCRIPTION
These changes allow the creation of `FloatWaveform` objects
from NumPy arrays in the Python interface

and from 1-dimensional Python lists.

and from 1-dimensional Rust vectors.