### PR TITLE
Upgrade to Symphonia 0.4.0. Remove Cargo Source Replacement

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,13 +2,6 @@
 [source.crates-io]
 replace-with = "vendored-sources"
 
-# Vendor dependencies from Neocrym's GitHub fork of the Symphonia crate.
-# (But again, we aren't checking it into *this* Git repository.)
-[source."https://github.com/neocrym-forks/Symphonia"]
-git = "https://github.com/neocrym-forks/Symphonia"
-rev = "2cafae82b664ceb14dd5d058f534574399764165"
-replace-with = "vendored-sources"
-
 [source.vendored-sources]
 directory = "vendor"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,8 @@ required-features = ["frontend-binary"]
 name = "babycat"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
-[patch.crates-io]
-symphonia = { git = "https://github.com/neocrym-forks/Symphonia", rev = "2cafae82b664ceb14dd5d058f534574399764165" }
-
 [dependencies]
-# we patch this dependency with our own fork
-symphonia = { version = "0.3.0",  features = [ "aac", "flac", "mp3", "pcm", "isomp4", "wav", "ogg" ] }
+symphonia = { version = "0.4.0",  features = [ "aac", "flac", "mp3", "pcm", "isomp4", "wav", "ogg", "vorbis" ] }
 
 base64 = "0.13"
 float-cmp= "0.8"


### PR DESCRIPTION
This allows us to publish our Babycat crate to crates.io.