### PR TITLE
Add the `FloatWaveform.from_many_files_to_numpy()` staticmethod to the Python frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ WHEEL_DIR ?= target/frontend-python
 MANYLINUX_WHEEL_DIR ?= target/frontend-python--manylinux
 VENV_PATH ?= venv
 CREATE_VENV_CMD ?= $(PYTHON) -m venv $(VENV_PATH)
-PYTHON_CODE_PATHS ?= ./tests-python ./docs/source/conf.py
+PYTHON_CODE_PATHS ?= ./benches-python ./tests-python ./docs/source/conf.py
 
 
 # Windows and Unix have different paths for activating
@@ -550,8 +550,13 @@ bench-rust: .b/init-rust
 	CARGO_TARGET_DIR=target/frontend-rust $(CARGO) bench
 .PHONY: bench-rust
 
+## bench-python
+bench-python: .b/init-python .b/install-python-wheel
+	$(ACTIVATE_VENV_CMD) && pytest benches-python/*
+.PHONY: bench-python
+
 ## bench
-bench: bench-rust
+bench: bench-rust bench-python
 .PHONY: bench
 
 

--- a/benches-python/bench_float_waveform_from_many_files.py
+++ b/benches-python/bench_float_waveform_from_many_files.py
@@ -1,0 +1,39 @@
+"""
+Run benchmarks comparing FloatWaveform.from_many_files to FloatWaveform.from_many_files_to_numpy.
+
+We want to make it as *fast* as possible to convert a list of audio files on disk
+into a list of NumPy arrays in memory.
+"""
+from babycat import FloatWaveform
+
+NUM_FILENAMES_1 = 48
+FILENAMES_1 = ["./audio-for-tests/circus-of-freaks/track.mp3"] * NUM_FILENAMES_1
+
+
+def from_many_files_no_iteration_1():
+    """Decode audio files, but don't convert them into NumPy arrays."""
+    FloatWaveform.from_many_files(FILENAMES_1)
+
+
+def test_bench_from_many_files_no_iteration_1(benchmark):
+    benchmark(from_many_files_no_iteration_1)
+
+
+def from_many_files_1():
+    """Decode audio files, but convert them to NumPy arrays on the Python side."""
+    named_results = FloatWaveform.from_many_files(FILENAMES_1)
+    for nr in named_results:
+        nr.waveform.to_numpy()
+
+
+def test_bench_from_many_files_1(benchmark):
+    benchmark(from_many_files_1)
+
+
+def from_many_files_to_numpy_1():
+    """Decode audio files, but convert them into NumPy arrays on the Rust side."""
+    FloatWaveform.from_many_files_to_numpy(FILENAMES_1)
+
+
+def test_bench_from_many_files_to_numpy_1(benchmark):
+    benchmark(from_many_files_to_numpy_1)

--- a/docs/source/api/python/FloatWaveform/from_many_files_to_numpy.rst
+++ b/docs/source/api/python/FloatWaveform/from_many_files_to_numpy.rst
@@ -1,0 +1,4 @@
+FloatWaveform.from_many_files_to_numpy()
+========================================
+
+.. automethod:: babycat.FloatWaveform.from_many_files_to_numpy

--- a/docs/source/api/python/FloatWaveform/index.rst
+++ b/docs/source/api/python/FloatWaveform/index.rst
@@ -40,6 +40,7 @@ Decoding audio
    .from_encoded_bytes() <from_encoded_bytes>
    .from_file() <from_file>
    .from_many_files() <from_many_files>
+   .from_many_files_to_numpy() <from_many_files_to_numpy>
 
 
 Resampling audio

--- a/makefile-help.txt
+++ b/makefile-help.txt
@@ -167,6 +167,7 @@ doctest-rust
 
 -----------------------------------------------------------------------
 bench                           Run benchmarks.
+bench-python
 bench-rust
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,6 @@ pylint==2.7.4
 
 # type annotations
 mypy==0.812
+
+# helps us run benchmarks
+pytest-benchmark==3.4.1

--- a/tests-python/test_doctests.py
+++ b/tests-python/test_doctests.py
@@ -31,3 +31,7 @@ def test_float_waveform_from_file():
 
 def test_float_waveform_from_many_files():
     run_doctest(babycat.FloatWaveform.from_many_files)
+
+
+def test_float_waveform_from_many_files_to_numpy():
+    run_doctest(babycat.FloatWaveform.from_many_files_to_numpy)

--- a/tests-python/test_float_waveform_from_many_files_to_numpy.py
+++ b/tests-python/test_float_waveform_from_many_files_to_numpy.py
@@ -1,0 +1,42 @@
+"""
+Tests that we can directly decode NumPy arrays to waveforms.
+"""
+import pytest
+from fixtures import *
+
+from babycat import FloatWaveform
+
+ALL_SAME_FILENAMES = [COF_FILENAME, COF_FILENAME, COF_FILENAME]
+
+
+def test_empty():
+    """Test from_many_files_to_numpy if we provide no filenames at all."""
+    arrays = FloatWaveform.from_many_files_to_numpy([])
+    assert len(arrays) == 0
+
+
+def test_all_same_file_1():
+    arrays = FloatWaveform.from_many_files_to_numpy(ALL_SAME_FILENAMES)
+    assert len(arrays) == 3
+    for arr in arrays:
+        assert arr.shape == (COF_NUM_FRAMES, COF_NUM_CHANNELS)
+
+
+def test_all_same_file_2():
+    arrays = FloatWaveform.from_many_files_to_numpy(
+        ALL_SAME_FILENAMES,
+        end_time_milliseconds=15000,
+    )
+    for arr in arrays:
+        assert arr.shape == (661500, 2)
+
+
+def test_different_filenames_1():
+    arrays = FloatWaveform.from_many_files_to_numpy(ALL_FILENAMES)
+    for i, arr in enumerate(arrays):
+        assert arr.shape == (ALL_NUM_FRAMES[i], ALL_NUM_CHANNELS[i])
+
+
+def test_file_not_found_error_1():
+    with pytest.raises(FileNotFoundError):
+        FloatWaveform.from_many_files_to_numpy([COF_FILENAME, "asdfadsfdas"])


### PR DESCRIPTION
This makes it slightly faster to process lots of input audio files into
NumPy arrays.