### PR TITLE
Rename `DecodeArgs` to `WaveformArgs`

### DIFF
--- a/docs/source/api/c/babycat_DecodeArgs/babycat_decode_args_init_default.rst
+++ b/docs/source/api/c/babycat_DecodeArgs/babycat_decode_args_init_default.rst
@@ -1,4 +1,0 @@
-babycat_decode_args_init_default()
-==================================
-
-.. doxygenfunction:: babycat_decode_args_init_default

--- a/docs/source/api/c/babycat_WaveformArgs/babycat_waveform_args_init_default.rst
+++ b/docs/source/api/c/babycat_WaveformArgs/babycat_waveform_args_init_default.rst
@@ -1,0 +1,4 @@
+babycat_waveform_args_init_default()
+====================================
+
+.. doxygenfunction:: babycat_waveform_args_init_default

--- a/docs/source/api/c/babycat_WaveformArgs/index.rst
+++ b/docs/source/api/c/babycat_WaveformArgs/index.rst
@@ -1,16 +1,16 @@
-babycat_DecodeArgs
-==================
+babycat_WaveformArgs
+====================
 
 .. toctree::
    :maxdepth: 2
    :hidden:
 
-   babycat_decode_args_init_default
+   babycat_waveform_args_init_default
 
 Struct members
 --------------
 
-.. doxygenstruct:: babycat_DecodeArgs
+.. doxygenstruct:: babycat_WaveformArgs
    :members:
    :protected-members:
    :private-members:
@@ -20,4 +20,4 @@ Struct members
 Relevant functions
 ------------------
 
-- :doc:`babycat_decode_args_init_default`
+- :doc:`babycat_waveform_args_init_default`

--- a/docs/source/api/c/index.rst
+++ b/docs/source/api/c/index.rst
@@ -5,7 +5,7 @@ Babycat C API Documentation
    :maxdepth: 1
    :hidden:
 
-   babycat_DecodeArgs/index
+   babycat_WaveformArgs/index
    babycat_Waveform/index
    babycat_WaveformResult/index
 
@@ -19,7 +19,7 @@ This documentation website splits the Babycat C API across multiple pages, but t
 Data structures (structs and typedefs)
 --------------------------------------
 
-- :doc:`babycat_DecodeArgs/index`: A struct that describes settings for decoding audio.
+- :doc:`babycat_WaveformArgs/index`: A struct that describes settings for decoding audio.
 - :doc:`babycat_Waveform/index`: A typedef struct that represents a single waveform in memory.
 - :doc:`babycat_WaveformResult/index`: A struct that contains either an error code or a pointer to a :doc:`babycat_Waveform/index`.
 

--- a/docs/source/api/python/Waveform/frame_rate_hz.rst
+++ b/docs/source/api/python/Waveform/frame_rate_hz.rst
@@ -1,4 +1,4 @@
 Waveform.frame_rate_hz
-=======================
+======================
 
 .. autodata:: babycat.Waveform.frame_rate_hz

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -163,13 +163,13 @@ This is an example of decoding a file named ``'audio.mp3'`` into memory and then
 
    .. code:: rust
 
-      use babycat::{DecodeArgs, Waveform};
+      use babycat::{WaveformArgs, Waveform};
 
       fn main() {
-         let decode_args = DecodeArgs {
+         let waveform_args = WaveformArgs {
             ..Default::default()
          };
-         let waveform = match Waveform::from_file("audio.mp3", decode_args) {
+         let waveform = match Waveform::from_file("audio.mp3", waveform_args) {
             Ok(w) => w,
             Err(err) => {
                   println!("Decoding error: {}", err);
@@ -233,9 +233,9 @@ This is an example of decoding a file named ``'audio.mp3'`` into memory and then
 
 
       int main() {
-         babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
+         babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
          babycat_WaveformResult waveform_result =
-               babycat_waveform_from_file("audio.mp3", decode_args);
+               babycat_waveform_from_file("audio.mp3", waveform_args);
          if (waveform_result.error_num != 0) {
             printf("Decoding error: %u", waveform_result.error_num);
             return 1;

--- a/examples-c/decode.c
+++ b/examples-c/decode.c
@@ -2,9 +2,9 @@
 #include <stdio.h>
 
 int main() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
   babycat_WaveformResult waveform_result = babycat_waveform_from_file(
-      "audio-for-tests/circus-of-freaks/track.mp3", decode_args);
+      "audio-for-tests/circus-of-freaks/track.mp3", waveform_args);
   if (waveform_result.error_num != 0) {
     printf("Decoding error: %u", waveform_result.error_num);
     return 1;

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,11 +1,11 @@
-use babycat::{DecodeArgs, Waveform};
+use babycat::{Waveform, WaveformArgs};
 
 fn main() {
-    let decode_args = DecodeArgs {
+    let waveform_args = WaveformArgs {
         ..Default::default()
     };
     let waveform =
-        match Waveform::from_file("audio-for-tests/circus-of-freaks/track.mp3", decode_args) {
+        match Waveform::from_file("audio-for-tests/circus-of-freaks/track.mp3", waveform_args) {
             Ok(w) => w,
             Err(err) => {
                 println!("Decoding error: {}", err);

--- a/src/backend/decode/symphonia.rs
+++ b/src/backend/decode/symphonia.rs
@@ -15,8 +15,8 @@ use symphonia::core::probe::Hint;
 use symphonia::core::sample::{i24, u24};
 
 use crate::backend::decode::Decoder;
-use crate::backend::decode_args::*;
 use crate::backend::errors::Error;
+use crate::backend::waveform_args::*;
 
 /// A generic enum covering all of the [AudioBuffer] sample tyes.
 enum AudioBufferType {

--- a/src/backend/errors.rs
+++ b/src/backend/errors.rs
@@ -10,26 +10,26 @@ pub enum Error {
     FeatureNotCompiled(&'static str),
     //
     // Input validation errors
-    /// Raised when [`DecodeArgs.start_time_milliseconds`][crate::DecodeArgs#structfield.start_time_milliseconds] or [`DecodeArgs.end_time_milliseconds`][crate::DecodeArgs#structfield.end_time_milliseconds] is invalid.
+    /// Raised when [`WaveformArgs.start_time_milliseconds`][crate::WaveformArgs#structfield.start_time_milliseconds] or [`WaveformArgs.end_time_milliseconds`][crate::WaveformArgs#structfield.end_time_milliseconds] is invalid.
     ///
     /// For example, this error is raised if you set the end timestamp to be before
     /// the start timestamp.
     WrongTimeOffset(u64, u64),
     /// Raised when you wanted to decode more channels than the audio actually had.
     WrongNumChannels(u32, u32),
-    /// Raised if you specified [`DecodeArgs.convert_to_mono`][crate::DecodeArgs#structfield.convert_to_mono] as `true` and [`DecodeArgs.num_channels`][crate::DecodeArgs#structfield.num_channels] as 1.
+    /// Raised if you specified [`WaveformArgs.convert_to_mono`][crate::WaveformArgs#structfield.convert_to_mono] as `true` and [`WaveformArgs.num_channels`][crate::WaveformArgs#structfield.num_channels] as 1.
     ///
     /// Setting both parameters is redundant and contradictory. You should either use
-    /// [`DecodeArgs.convert_to_mono`][crate::DecodeArgs#structfield.convert_to_mono]
-    /// to flatten all channels or [`DecodeArgs.num_channels`][crate::DecodeArgs#structfield.num_channels] = 1 to select the first channel and discard the rest.
-    /// You can set [`DecodeArgs.num_channels`][crate::DecodeArgs#structfield.num_channels]
-    /// `n > 1` and use  [`DecodeArgs.convert_to_mono`][crate::DecodeArgs#structfield.convert_to_mono] to only flatten those `n` channels.
+    /// [`WaveformArgs.convert_to_mono`][crate::WaveformArgs#structfield.convert_to_mono]
+    /// to flatten all channels or [`WaveformArgs.num_channels`][crate::WaveformArgs#structfield.num_channels] = 1 to select the first channel and discard the rest.
+    /// You can set [`WaveformArgs.num_channels`][crate::WaveformArgs#structfield.num_channels]
+    /// `n > 1` and use  [`WaveformArgs.convert_to_mono`][crate::WaveformArgs#structfield.convert_to_mono] to only flatten those `n` channels.
     /// If you need to select channels in some other way, then do not provide either
-    /// [`DecodeArgs.convert_to_mono`][crate::DecodeArgs#structfield.convert_to_mono]
-    /// or [`DecodeArgs.num_channels`][crate::DecodeArgs#structfield.num_channels].
+    /// [`WaveformArgs.convert_to_mono`][crate::WaveformArgs#structfield.convert_to_mono]
+    /// or [`WaveformArgs.num_channels`][crate::WaveformArgs#structfield.num_channels].
     /// All channels will be decoded and you can decide what to do with them.
     WrongNumChannelsAndMono,
-    /// Raised if you set [`DecodeArgs.zero_pad_ending`][crate::DecodeArgs#structfield.zero_pad_ending] as `true` without also specifying [`DecodeArgs.end_time_milliseconds`][crate::DecodeArgs#structfield.end_time_milliseconds].
+    /// Raised if you set [`WaveformArgs.zero_pad_ending`][crate::WaveformArgs#structfield.zero_pad_ending] as `true` without also specifying [`WaveformArgs.end_time_milliseconds`][crate::WaveformArgs#structfield.end_time_milliseconds].
     CannotZeroPadWithoutSpecifiedLength,
     //
     // Decoding errors

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,14 +1,14 @@
 mod batch_args;
 mod common;
 pub mod decode;
-mod decode_args;
 mod errors;
 mod named_result;
 pub mod resample;
 mod waveform;
+mod waveform_args;
 
 pub use batch_args::*;
-pub use decode_args::*;
 pub use errors::*;
 pub use named_result::*;
 pub use waveform::*;
+pub use waveform_args::*;

--- a/src/backend/resample/mod.rs
+++ b/src/backend/resample/mod.rs
@@ -10,11 +10,11 @@ pub mod babycat_sinc;
 pub mod common;
 pub mod libsamplerate;
 
-use crate::backend::decode_args::DEFAULT_RESAMPLE_MODE;
-use crate::backend::decode_args::RESAMPLE_MODE_BABYCAT_LANCZOS;
-use crate::backend::decode_args::RESAMPLE_MODE_BABYCAT_SINC;
-use crate::backend::decode_args::RESAMPLE_MODE_LIBSAMPLERATE;
 use crate::backend::errors::Error;
+use crate::backend::waveform_args::DEFAULT_RESAMPLE_MODE;
+use crate::backend::waveform_args::RESAMPLE_MODE_BABYCAT_LANCZOS;
+use crate::backend::waveform_args::RESAMPLE_MODE_BABYCAT_SINC;
+use crate::backend::waveform_args::RESAMPLE_MODE_LIBSAMPLERATE;
 
 pub fn resample(
     input_frame_rate_hz: u32,

--- a/src/backend/waveform_args.rs
+++ b/src/backend/waveform_args.rs
@@ -41,7 +41,7 @@ pub const DECODING_BACKEND_SYMPHONIA: u32 = 1;
 /// as-is and not change anything.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DecodeArgs {
+pub struct WaveformArgs {
     /// We discard any audio before this millisecond
     /// offset. By default, this does nothing and the
     /// audio is decoded from the beginning.
@@ -105,9 +105,9 @@ pub struct DecodeArgs {
     pub decoding_backend: u32,
 }
 
-impl Default for DecodeArgs {
+impl Default for WaveformArgs {
     fn default() -> Self {
-        DecodeArgs {
+        WaveformArgs {
             start_time_milliseconds: DEFAULT_START_TIME_MILLISECONDS,
             end_time_milliseconds: DEFAULT_END_TIME_MILLISECONDS,
             frame_rate_hz: DEFAULT_FRAME_RATE_HZ,

--- a/src/bin/babycat/commands/convert.rs
+++ b/src/bin/babycat/commands/convert.rs
@@ -1,7 +1,7 @@
 use log::info;
 
-use babycat::DecodeArgs;
 use babycat::Waveform;
+use babycat::WaveformArgs;
 use babycat::DECODING_BACKEND_SYMPHONIA;
 use babycat::RESAMPLE_MODE_BABYCAT_LANCZOS;
 use babycat::RESAMPLE_MODE_BABYCAT_SINC;
@@ -52,7 +52,7 @@ pub fn convert(
     };
     //
     // Set up decoding.
-    let decode_args = DecodeArgs {
+    let waveform_args = WaveformArgs {
         start_time_milliseconds,
         end_time_milliseconds,
         frame_rate_hz,
@@ -65,7 +65,7 @@ pub fn convert(
     //
     // Decode from filesystem.
     let decoding_start_time = std::time::Instant::now();
-    let waveform = Waveform::from_file(input_filename, decode_args).unwrap_or_exit();
+    let waveform = Waveform::from_file(input_filename, waveform_args).unwrap_or_exit();
     let decoding_elapsed = std::time::Instant::now() - decoding_start_time;
     info!(
         "Decoded {} frames of {} channels at {} hz in {} seconds from {}",

--- a/src/frontends/c.rs
+++ b/src/frontends/c.rs
@@ -1,6 +1,6 @@
-use crate::backend::DecodeArgs;
 use crate::backend::Error;
 use crate::backend::Waveform;
+use crate::backend::WaveformArgs;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
@@ -119,10 +119,10 @@ impl From<Result<Waveform, Error>> for WaveformResult {
     }
 }
 
-/// Returns a `babycat_DecodeArgs` struct with all default values.
+/// Returns a `babycat_WaveformArgs` struct with all default values.
 #[no_mangle]
-pub extern "C" fn babycat_decode_args_init_default() -> DecodeArgs {
-    DecodeArgs {
+pub extern "C" fn babycat_waveform_args_init_default() -> WaveformArgs {
+    WaveformArgs {
         ..Default::default()
     }
 }
@@ -170,7 +170,7 @@ pub extern "C" fn babycat_waveform_from_milliseconds_of_silence(
 ///
 /// @param encoded_bytes A byte array containing encoded (e.g. MP3) audio.
 /// @param encoded_bytes_len The length of the `encoded_bytes` byte array.
-/// @param decode_args Instructions on how to decode the audio.
+/// @param waveform_args Instructions on how to decode the audio.
 /// @param file_extension A hint, in the form of a file extension, to indicate
 ///        the encoding of the audio in `encoded_bytes`.
 /// @param mime_type A hint, in the form of a MIME type, to indicate
@@ -181,7 +181,7 @@ pub extern "C" fn babycat_waveform_from_milliseconds_of_silence(
 pub unsafe extern "C" fn babycat_waveform_from_encoded_bytes_with_hint(
     encoded_bytes: *mut u8,
     encoded_bytes_len: usize,
-    decode_args: DecodeArgs,
+    waveform_args: WaveformArgs,
     file_extension: *const c_char,
     mime_type: *const c_char,
 ) -> WaveformResult {
@@ -191,7 +191,7 @@ pub unsafe extern "C" fn babycat_waveform_from_encoded_bytes_with_hint(
     let mime_type_str = CStr::from_ptr(mime_type).to_str().unwrap();
     Waveform::from_encoded_bytes_with_hint(
         &encoded_bytes_vec,
-        decode_args,
+        waveform_args,
         file_extension_str,
         mime_type_str,
     )
@@ -202,33 +202,33 @@ pub unsafe extern "C" fn babycat_waveform_from_encoded_bytes_with_hint(
 ///
 /// @param encoded_bytes A byte array containing encoded (e.g. MP3) audio.
 /// @param encoded_bytes_len The length of the `encoded_bytes` byte array.
-/// @param decode_args Instructions on how to decode the audio.
+/// @param waveform_args Instructions on how to decode the audio.
 ///
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_waveform_from_encoded_bytes(
     encoded_bytes: *mut u8,
     encoded_bytes_len: usize,
-    decode_args: DecodeArgs,
+    waveform_args: WaveformArgs,
 ) -> WaveformResult {
     let encoded_bytes_vec =
         Vec::<u8>::from_raw_parts(encoded_bytes, encoded_bytes_len, encoded_bytes_len);
-    Waveform::from_encoded_bytes(&encoded_bytes_vec, decode_args).into()
+    Waveform::from_encoded_bytes(&encoded_bytes_vec, waveform_args).into()
 }
 
 /// Decodes audio stored in a local file.
 ///
 /// @param filename A filename of an encoded audio file on the local filesystem.
-/// @param decode_args Instructions on how to decode the audio.
+/// @param waveform_args Instructions on how to decode the audio.
 ///
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_waveform_from_file(
     filename: *const c_char,
-    decode_args: DecodeArgs,
+    waveform_args: WaveformArgs,
 ) -> WaveformResult {
     let filename_rust = CStr::from_ptr(filename).to_str().unwrap();
-    Waveform::from_file(filename_rust, decode_args).into()
+    Waveform::from_file(filename_rust, waveform_args).into()
 }
 
 /// Returns the frame rate of an existing `babycat_Waveform`.

--- a/src/frontends/python/waveform.rs
+++ b/src/frontends/python/waveform.rs
@@ -459,7 +459,7 @@ impl Waveform {
         file_extension: &str,
         mime_type: &str,
     ) -> PyResult<Self> {
-        let decode_args = crate::backend::DecodeArgs {
+        let waveform_args = crate::backend::WaveformArgs {
             start_time_milliseconds,
             end_time_milliseconds,
             frame_rate_hz,
@@ -471,7 +471,7 @@ impl Waveform {
         };
         waveform_to_pyresult(crate::backend::Waveform::from_encoded_bytes_with_hint(
             &encoded_bytes,
-            decode_args,
+            waveform_args,
             file_extension,
             mime_type,
         ))
@@ -671,7 +671,7 @@ impl Waveform {
         resample_mode: u32,
         decoding_backend: u32,
     ) -> PyResult<Self> {
-        let decode_args = crate::backend::DecodeArgs {
+        let waveform_args = crate::backend::WaveformArgs {
             start_time_milliseconds,
             end_time_milliseconds,
             frame_rate_hz,
@@ -681,7 +681,7 @@ impl Waveform {
             resample_mode,
             decoding_backend,
         };
-        waveform_to_pyresult(crate::backend::Waveform::from_file(filename, decode_args))
+        waveform_to_pyresult(crate::backend::Waveform::from_file(filename, waveform_args))
     }
 
     /// Uses multithreading in Rust to decode many audio files in parallel.
@@ -852,7 +852,7 @@ impl Waveform {
         decoding_backend: u32,
         num_workers: usize,
     ) -> Vec<WaveformNamedResult> {
-        let decode_args = crate::backend::DecodeArgs {
+        let waveform_args = crate::backend::WaveformArgs {
             start_time_milliseconds,
             end_time_milliseconds,
             frame_rate_hz,
@@ -864,7 +864,7 @@ impl Waveform {
         };
         let batch_args = crate::backend::BatchArgs { num_workers };
         let filenames_ref: Vec<&str> = filenames.iter().map(|f| f.as_str()).collect();
-        crate::backend::Waveform::from_many_files(&filenames_ref, decode_args, batch_args)
+        crate::backend::Waveform::from_many_files(&filenames_ref, waveform_args, batch_args)
             .into_iter()
             .map(WaveformNamedResult::from)
             .collect()

--- a/src/frontends/wasm.rs
+++ b/src/frontends/wasm.rs
@@ -46,14 +46,14 @@ impl Waveform {
     /// Decodes audio stored in an in-memory byte array.
     pub fn fromEncodedArray(
         encodedArray: Uint8Array,
-        decodeArgs: JsValue,
+        WaveformArgs: JsValue,
     ) -> Result<Waveform, JsValue> {
-        let parsedDecodeArgs: crate::backend::DecodeArgs = match decodeArgs.into_serde() {
+        let parsedWaveformArgs: crate::backend::WaveformArgs = match WaveformArgs.into_serde() {
             Ok(parsed) => parsed,
             Err(err) => return Err(throw_js_error(err)),
         };
         let cursor = std::io::Cursor::new(encodedArray.to_vec());
-        match crate::backend::Waveform::from_encoded_stream(cursor, parsedDecodeArgs) {
+        match crate::backend::Waveform::from_encoded_stream(cursor, parsedWaveformArgs) {
             Ok(inner) => Ok(Waveform { inner }),
             Err(err) => Err(throw_js_error(err)),
         }
@@ -62,18 +62,18 @@ impl Waveform {
     /// Decodes audio using an in-memory byte array, using user-specified encoding hints.
     pub fn fromEncodedArrayWithHint(
         encodedArray: Uint8Array,
-        decodeArgs: JsValue,
+        WaveformArgs: JsValue,
         fileExtension: &str,
         mimeType: &str,
     ) -> Result<Waveform, JsValue> {
-        let parsedDecodeArgs: crate::backend::DecodeArgs = match decodeArgs.into_serde() {
+        let parsedWaveformArgs: crate::backend::WaveformArgs = match WaveformArgs.into_serde() {
             Ok(parsed) => parsed,
             Err(err) => return Err(throw_js_error(err)),
         };
         let cursor = std::io::Cursor::new(encodedArray.to_vec());
         match crate::backend::Waveform::from_encoded_stream_with_hint(
             cursor,
-            parsedDecodeArgs,
+            parsedWaveformArgs,
             fileExtension,
             mimeType,
         ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! # Examples
 //! **Decode multiple audio files in parallel.**
 //! ```
-//! use babycat::{DecodeArgs, Waveform};
+//! use babycat::{WaveformArgs, Waveform};
 //!
 //! // These are test files in the Babycat Git repository.
 //! let filenames = &[
@@ -64,7 +64,7 @@
 //! ];
 //!
 //! // Perform the following transformations on EACH track.
-//! let decode_args = DecodeArgs {
+//! let waveform_args = WaveformArgs {
 //!     // Upsample the audio to 48khz.
 //!     frame_rate_hz: 48000,
 //!     // Average all audio channels into a single monophonic channel.
@@ -80,7 +80,7 @@
 //! // Read and decode the tracks in parallel.
 //! let batch = babycat::Waveform::from_many_files(
 //!    filenames,
-//!    decode_args,
+//!    waveform_args,
 //!    batch_args,
 //! );
 //!

--- a/tests-c/test.c
+++ b/tests-c/test.c
@@ -14,13 +14,13 @@ const uint32_t RESAMPLING_MODES[NUM_RESAMPLING_MODES] = {
 // so we know that the test succeeded.
 #define SUCCESS() fprintf(stderr, "Success: %s\n", __FUNCTION__)
 
-#define DECODE_COF(decode_args)                                                \
+#define DECODE_COF(waveform_args)                                              \
   babycat_waveform_from_file("./audio-for-tests/circus-of-freaks/track.mp3",   \
-                             decode_args)
+                             waveform_args)
 
 static void test_waveform_from_file__test_circus_of_freaks_default_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -32,40 +32,40 @@ static void test_waveform_from_file__test_circus_of_freaks_default_1() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_wrong_time_offset_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 1000;
-  decode_args.end_time_milliseconds = 999;
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 1000;
+  waveform_args.end_time_milliseconds = 999;
 
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_ERROR_WRONG_TIME_OFFSET);
   SUCCESS();
 }
 
 static void
 test_waveform_from_file__test_circus_of_freaks_wrong_time_offset_2() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 1000;
-  decode_args.end_time_milliseconds = 1000;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 1000;
+  waveform_args.end_time_milliseconds = 1000;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_ERROR_WRONG_TIME_OFFSET);
   SUCCESS();
 }
 
 static void
 test_waveform_from_file__test_circus_of_freaks_invalid_end_time_milliseconds_zero_pad_ending_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 5;
-  decode_args.end_time_milliseconds = 0;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 5;
+  waveform_args.end_time_milliseconds = 0;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_ERROR_CANNOT_ZERO_PAD);
   SUCCESS();
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_get_channels_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.num_channels = 1;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.num_channels = 1;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 1);
@@ -76,9 +76,9 @@ static void test_waveform_from_file__test_circus_of_freaks_get_channels_1() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_get_channels_2() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.num_channels = 2;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.num_channels = 2;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -90,18 +90,18 @@ static void test_waveform_from_file__test_circus_of_freaks_get_channels_2() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_get_channels_too_many_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.num_channels = 3;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.num_channels = 3;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_ERROR_WRONG_NUM_CHANNELS);
   SUCCESS();
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_convert_to_mono_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.num_channels = 2;
-  decode_args.convert_to_mono = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.num_channels = 2;
+  waveform_args.convert_to_mono = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 1);
@@ -112,9 +112,9 @@ static void test_waveform_from_file__test_circus_of_freaks_convert_to_mono_1() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_convert_to_mono_2() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.convert_to_mono = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.convert_to_mono = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 1);
@@ -126,10 +126,10 @@ static void test_waveform_from_file__test_circus_of_freaks_convert_to_mono_2() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_convert_to_mono_invalid_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.num_channels = 1;
-  decode_args.convert_to_mono = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.num_channels = 1;
+  waveform_args.convert_to_mono = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num ==
          babycat_ERROR_WRONG_NUM_CHANNELS_AND_MONO);
   SUCCESS();
@@ -137,10 +137,10 @@ test_waveform_from_file__test_circus_of_freaks_convert_to_mono_invalid_1() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 0;
-  decode_args.end_time_milliseconds = 1;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 0;
+  waveform_args.end_time_milliseconds = 1;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -152,10 +152,10 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_1() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_2() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 10;
-  decode_args.end_time_milliseconds = 11;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 10;
+  waveform_args.end_time_milliseconds = 11;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -167,10 +167,10 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_2() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_3() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 0;
-  decode_args.end_time_milliseconds = 30000;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 0;
+  waveform_args.end_time_milliseconds = 30000;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -182,10 +182,10 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_3() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_4() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 15000;
-  decode_args.end_time_milliseconds = 45000;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 15000;
+  waveform_args.end_time_milliseconds = 45000;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -197,10 +197,10 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_4() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_5() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 30000;
-  decode_args.end_time_milliseconds = 60000;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 30000;
+  waveform_args.end_time_milliseconds = 60000;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -212,11 +212,11 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_5() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 0;
-  decode_args.end_time_milliseconds = 1;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 0;
+  waveform_args.end_time_milliseconds = 1;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -228,11 +228,11 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_e
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_2() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 10;
-  decode_args.end_time_milliseconds = 11;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 10;
+  waveform_args.end_time_milliseconds = 11;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -244,11 +244,11 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_e
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_3() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 0;
-  decode_args.end_time_milliseconds = 30000;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 0;
+  waveform_args.end_time_milliseconds = 30000;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -260,11 +260,11 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_e
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_4() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 15000;
-  decode_args.end_time_milliseconds = 45000;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 15000;
+  waveform_args.end_time_milliseconds = 45000;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -276,11 +276,11 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_e
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_5() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 30000;
-  decode_args.end_time_milliseconds = 60000;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 30000;
+  waveform_args.end_time_milliseconds = 60000;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -292,11 +292,11 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_e
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_6() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 0;
-  decode_args.end_time_milliseconds = 60000;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 0;
+  waveform_args.end_time_milliseconds = 60000;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -308,11 +308,11 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_e
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_7() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 0;
-  decode_args.end_time_milliseconds = 90000;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 0;
+  waveform_args.end_time_milliseconds = 90000;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -324,11 +324,11 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_e
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_8() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 30000;
-  decode_args.end_time_milliseconds = 90000;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 30000;
+  waveform_args.end_time_milliseconds = 90000;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -340,10 +340,10 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_zero_pad_e
 
 static void
 test_waveform_from_file__test_circus_of_freaks_end_milliseconds_zero_pad_ending_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.end_time_milliseconds = 90000;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.end_time_milliseconds = 90000;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -355,36 +355,36 @@ test_waveform_from_file__test_circus_of_freaks_end_milliseconds_zero_pad_ending_
 
 static void
 test_waveform_from_file__test_circus_of_freaks_invalid_resample_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 1;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 1;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_ERROR_WRONG_FRAME_RATE_RATIO);
   SUCCESS();
 }
 
 static void
 test_waveform_from_file__test_circus_of_freaks_invalid_resample_2() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 20;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 20;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_ERROR_WRONG_FRAME_RATE_RATIO);
   SUCCESS();
 }
 
 static void
 test_waveform_from_file__test_circus_of_freaks_invalid_resample_3() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 172;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 172;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_ERROR_WRONG_FRAME_RATE_RATIO);
   SUCCESS();
 }
 
 static void
 test_waveform_from_file__test_circus_of_freaks_resample_no_change() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 44100;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 44100;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -395,9 +395,9 @@ test_waveform_from_file__test_circus_of_freaks_resample_no_change() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 22050;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 22050;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -408,9 +408,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_1() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_2() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 11025;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 11025;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -421,9 +421,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_2() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_3() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 88200;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 88200;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -434,9 +434,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_3() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_4() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 4410;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 4410;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -447,9 +447,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_4() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_5() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 44099;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 44099;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -460,9 +460,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_5() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_6() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 48000;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 48000;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -473,9 +473,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_6() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_7() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 60000;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 60000;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -486,9 +486,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_7() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_8() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 88200;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 88200;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -499,9 +499,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_8() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_9() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 96000;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 96000;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -512,9 +512,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_9() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_10() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 200;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 200;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -525,9 +525,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_10() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_11() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 2000;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 2000;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -538,9 +538,9 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_11() {
 }
 
 static void test_waveform_from_file__test_circus_of_freaks_resample_12() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.frame_rate_hz = 173;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.frame_rate_hz = 173;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -552,12 +552,12 @@ static void test_waveform_from_file__test_circus_of_freaks_resample_12() {
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_1() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 0;
-  decode_args.end_time_milliseconds = 60000;
-  decode_args.frame_rate_hz = 48000;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 0;
+  waveform_args.end_time_milliseconds = 60000;
+  waveform_args.frame_rate_hz = 48000;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -569,12 +569,12 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_resample_z
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_2() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 0;
-  decode_args.end_time_milliseconds = 60000;
-  decode_args.frame_rate_hz = 44099;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 0;
+  waveform_args.end_time_milliseconds = 60000;
+  waveform_args.frame_rate_hz = 44099;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -586,12 +586,12 @@ test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_resample_z
 
 static void
 test_waveform_from_file__test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_3() {
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  decode_args.start_time_milliseconds = 0;
-  decode_args.end_time_milliseconds = 60000;
-  decode_args.frame_rate_hz = 22050;
-  decode_args.zero_pad_ending = true;
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  waveform_args.start_time_milliseconds = 0;
+  waveform_args.end_time_milliseconds = 60000;
+  waveform_args.frame_rate_hz = 22050;
+  waveform_args.zero_pad_ending = true;
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   assert(babycat_waveform_get_num_channels(waveform) == 2);
@@ -606,8 +606,8 @@ static void test_waveform_resample_method__test_circus_of_freaks_no_change_1() {
   uint32_t expected_num_frames = 2491776;
   //
   // Decode the waveform the first time.
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   //
@@ -639,8 +639,8 @@ static void test_waveform_resample_method__test_circus_of_freaks_44099() {
   uint32_t expected_num_frames = 2491720;
   //
   // Decode the waveform the first time.
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   //
@@ -672,8 +672,8 @@ static void test_waveform_resample_method__test_circus_of_freaks_44101() {
   uint32_t expected_num_frames = 2491833;
   //
   // Decode the waveform the first time.
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   //
@@ -705,8 +705,8 @@ static void test_waveform_resample_method__test_circus_of_freaks_22050() {
   uint32_t expected_num_frames = 1245888;
   //
   // Decode the waveform the first time.
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   //
@@ -738,8 +738,8 @@ static void test_waveform_resample_method__test_circus_of_freaks_11025() {
   uint32_t expected_num_frames = 622944;
   //
   // Decode the waveform the first time.
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   //
@@ -771,8 +771,8 @@ static void test_waveform_resample_method__test_circus_of_freaks_88200() {
   uint32_t expected_num_frames = 4983552;
   //
   // Decode the waveform the first time.
-  babycat_DecodeArgs decode_args = babycat_decode_args_init_default();
-  babycat_WaveformResult waveform_result = DECODE_COF(decode_args);
+  babycat_WaveformArgs waveform_args = babycat_waveform_args_init_default();
+  babycat_WaveformResult waveform_result = DECODE_COF(waveform_args);
   assert(waveform_result.error_num == babycat_NO_ERROR);
   babycat_Waveform *waveform = waveform_result.result;
   //

--- a/tests-python/test_waveform_resample_method.py
+++ b/tests-python/test_waveform_resample_method.py
@@ -19,7 +19,7 @@ RESAMPLE_MODES = {
 def decode_and_assert(
     *,
     filename: str,
-    decode_args: dict,
+    waveform_args: dict,
     frame_rate_hz: int,
     expected_num_channels: int,
     expected_num_frames: int,
@@ -27,7 +27,7 @@ def decode_and_assert(
 ):
     waveform = Waveform.from_file(
         filename,
-        **decode_args,
+        **waveform_args,
     )
     for mode_name, resample_mode in RESAMPLE_MODES.items():
         resampled = waveform.resample_by_mode(
@@ -43,7 +43,7 @@ def decode_and_assert(
 def test_circus_of_freaks_no_change_1():
     decode_and_assert(
         filename=COF_FILENAME,
-        decode_args={},
+        waveform_args={},
         frame_rate_hz=COF_FRAME_RATE_HZ,
         expected_num_channels=COF_NUM_CHANNELS,
         expected_num_frames=COF_NUM_FRAMES,
@@ -54,7 +54,7 @@ def test_circus_of_freaks_no_change_1():
 def test_circus_of_freaks_44099():
     decode_and_assert(
         filename=COF_FILENAME,
-        decode_args={},
+        waveform_args={},
         frame_rate_hz=44099,
         expected_num_channels=COF_NUM_CHANNELS,
         expected_num_frames=2491720,
@@ -65,7 +65,7 @@ def test_circus_of_freaks_44099():
 def test_circus_of_freaks_44101():
     decode_and_assert(
         filename=COF_FILENAME,
-        decode_args={},
+        waveform_args={},
         frame_rate_hz=44101,
         expected_num_channels=COF_NUM_CHANNELS,
         expected_num_frames=2491833,
@@ -76,7 +76,7 @@ def test_circus_of_freaks_44101():
 def test_circus_of_freaks_22050():
     decode_and_assert(
         filename=COF_FILENAME,
-        decode_args={},
+        waveform_args={},
         frame_rate_hz=22050,
         expected_num_channels=COF_NUM_CHANNELS,
         expected_num_frames=COF_NUM_FRAMES // 2,
@@ -87,7 +87,7 @@ def test_circus_of_freaks_22050():
 def test_circus_of_freaks_11025():
     decode_and_assert(
         filename=COF_FILENAME,
-        decode_args={},
+        waveform_args={},
         frame_rate_hz=11025,
         expected_num_channels=COF_NUM_CHANNELS,
         expected_num_frames=COF_NUM_FRAMES // 4,
@@ -98,7 +98,7 @@ def test_circus_of_freaks_11025():
 def test_circus_of_freaks_88200():
     decode_and_assert(
         filename=COF_FILENAME,
-        decode_args={},
+        waveform_args={},
         frame_rate_hz=88200,
         expected_num_channels=COF_NUM_CHANNELS,
         expected_num_frames=COF_NUM_FRAMES * 2,

--- a/tests-wasm-nodejs/test.js
+++ b/tests-wasm-nodejs/test.js
@@ -43,8 +43,8 @@ describe("Waveform.fromEncodedArray", function () {
   this.timeout(0);
 
   it("test_circus_of_freaks_default_1", function () {
-    const decodeArgs = {};
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const WaveformArgs = {};
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(
       waveform,
       COF_NUM_CHANNELS,
@@ -54,240 +54,240 @@ describe("Waveform.fromEncodedArray", function () {
   });
 
   it("test_circus_of_freaks_wrong_time_offset_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 1000,
       end_time_milliseconds: 999,
     };
-    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, decodeArgs));
+    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, WaveformArgs));
   });
 
   it("test_circus_of_freaks_wrong_time_offset_2", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 1000,
       end_time_milliseconds: 1000,
     };
-    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, decodeArgs));
+    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, WaveformArgs));
   });
 
   it("test_circus_of_freaks_invalid_end_time_milliseconds_zero_pad_ending_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 5,
       end_time_milliseconds: 0,
       zero_pad_ending: true,
     };
-    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, decodeArgs));
+    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, WaveformArgs));
   });
 
   it("test_circus_of_freaks_get_channels_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       num_channels: 1,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, 1, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_get_channels_2", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       num_channels: 2,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, 2, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_get_channels_too_many_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       num_channels: 3,
     };
-    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, decodeArgs));
+    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, WaveformArgs));
   });
 
   it("test_circus_of_freaks_convert_to_mono_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       num_channels: 2,
       convert_to_mono: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, 1, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_convert_to_mono_2", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       convert_to_mono: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, 1, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_convert_to_mono_invalid_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       num_channels: 1,
       convert_to_mono: true,
     };
-    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, decodeArgs));
+    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, WaveformArgs));
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 0,
       end_time_milliseconds: 1,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 44, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_2", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 10,
       end_time_milliseconds: 11,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 44, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_3", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 0,
       end_time_milliseconds: 30000,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_4", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 15000,
       end_time_milliseconds: 45000,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_5", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 30000,
       end_time_milliseconds: 60000,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 1168776, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 0,
       end_time_milliseconds: 1,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 44, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_2", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 10,
       end_time_milliseconds: 11,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assert.strictEqual(waveform.numChannels(), COF_NUM_CHANNELS);
     assert.strictEqual(waveform.numFrames(), 44);
     assert.strictEqual(waveform.frameRateHz(), COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_3", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 0,
       end_time_milliseconds: 30000,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_4", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 15000,
       end_time_milliseconds: 45000,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_5", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 30000,
       end_time_milliseconds: 60000,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_6", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 0,
       end_time_milliseconds: 60000,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 2646000, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_7", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 30000,
       end_time_milliseconds: 90000,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 2646000, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_8", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 30000,
       end_time_milliseconds: 90000,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 2646000, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_end_milliseconds_zero_pad_ending_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       end_time_milliseconds: 90000,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 3969000, COF_FRAME_RATE_HZ);
   });
 
   it("test_circus_of_freaks_invalid_resample_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 1,
     };
-    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, decodeArgs));
+    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, WaveformArgs));
   });
 
   it("test_circus_of_freaks_invalid_resample_2", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 20,
     };
-    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, decodeArgs));
+    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, WaveformArgs));
   });
 
   it("test_circus_of_freaks_invalid_resample_3", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 172,
     };
-    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, decodeArgs));
+    assert.throws(() => babycat.Waveform.fromEncodedArray(COF, WaveformArgs));
   });
 
   it("test_circus_of_freaks_resample_no_change_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: COF_FRAME_RATE_HZ,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(
       waveform,
       COF_NUM_CHANNELS,
@@ -297,131 +297,131 @@ describe("Waveform.fromEncodedArray", function () {
   });
 
   it("test_circus_of_freaks_resample_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 22050,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 1245888, 22050);
   });
 
   it("test_circus_of_freaks_resample_2", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 11025,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 622944, 11025);
   });
 
   it("test_circus_of_freaks_resample_3", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 88200,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 4983552, 88200);
   });
 
   it("test_circus_of_freaks_resample_4", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 4410,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 249178, 4410);
   });
 
   it("test_circus_of_freaks_resample_5", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 44099,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 2491720, 44099);
   });
 
   it("test_circus_of_freaks_resample_6", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 48000,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 2712138, 48000);
   });
 
   it("test_circus_of_freaks_resample_7", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 60000,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 3390172, 60000);
   });
 
   it("test_circus_of_freaks_resample_8", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 88200,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 4983552, 88200);
   });
 
   it("test_circus_of_freaks_resample_9", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 96000,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 5424275, 96000);
   });
 
   it("test_circus_of_freaks_resample_10", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 200,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 11301, 200);
   });
 
   it("test_circus_of_freaks_resample_11", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 2000,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 113006, 2000);
   });
 
   it("test_circus_of_freaks_resample_12", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       frame_rate_hz: 173,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 9775, 173);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_1", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 0,
       end_time_milliseconds: 60000,
       frame_rate_hz: 48000,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 2880000, 48000);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_2", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 0,
       end_time_milliseconds: 60000,
       frame_rate_hz: 44099,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 2645940, 44099);
   });
 
   it("test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_3", function () {
-    const decodeArgs = {
+    const WaveformArgs = {
       start_time_milliseconds: 0,
       end_time_milliseconds: 60000,
       frame_rate_hz: 22050,
       zero_pad_ending: true,
     };
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     assertWaveform(waveform, COF_NUM_CHANNELS, 1323000, 22050);
   });
 });
@@ -430,8 +430,8 @@ describe("Waveform.resampleByMode", function () {
   this.timeout(0);
 
   function decodeAndAssertCOF(frameRateHz, expectedNumFrames) {
-    const decodeArgs = {};
-    const waveform = babycat.Waveform.fromEncodedArray(COF, decodeArgs);
+    const WaveformArgs = {};
+    const waveform = babycat.Waveform.fromEncodedArray(COF, WaveformArgs);
     const resampled = waveform.resampleByMode(frameRateHz, 2);
     assertWaveform(resampled, COF_NUM_CHANNELS, expectedNumFrames, frameRateHz);
   }

--- a/tests/test_waveform_from_file.rs
+++ b/tests/test_waveform_from_file.rs
@@ -2,16 +2,16 @@ mod fixtures;
 
 mod test_waveform_from_file {
     use crate::fixtures::*;
-    use babycat::DecodeArgs;
     use babycat::Error;
     use babycat::Waveform;
+    use babycat::WaveformArgs;
 
-    fn decode_cof_mp3(decode_args: DecodeArgs) -> Result<Waveform, Error> {
-        Waveform::from_file(COF_FILENAME, decode_args)
+    fn decode_cof_mp3(waveform_args: WaveformArgs) -> Result<Waveform, Error> {
+        Waveform::from_file(COF_FILENAME, waveform_args)
     }
 
-    fn decode_lct_mp3(decode_args: DecodeArgs) -> Result<Waveform, Error> {
-        Waveform::from_file(LCT_FILENAME, decode_args)
+    fn decode_lct_mp3(waveform_args: WaveformArgs) -> Result<Waveform, Error> {
+        Waveform::from_file(LCT_FILENAME, waveform_args)
     }
 
     fn assert_error(result: Result<Waveform, Error>, error_type: &str) {
@@ -36,94 +36,94 @@ mod test_waveform_from_file {
 
     #[test]
     fn test_circus_of_freaks_default_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_wrong_time_offset_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 1000,
             end_time_milliseconds: 999,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_error(result, "WrongTimeOffset(1000,999)");
     }
 
     #[test]
     fn test_circus_of_freaks_wrong_time_offset_2() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 1000,
             end_time_milliseconds: 1000,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_error(result, "WrongTimeOffset(1000,1000)");
     }
 
     #[test]
     fn test_circus_of_freaks_invalid_end_time_milliseconds_zero_pad_ending_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 5,
             end_time_milliseconds: 0,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_error(result, "CannotZeroPadWithoutSpecifiedLength");
     }
 
     #[test]
     fn test_circus_of_freaks_get_channels_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             num_channels: 1,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, 1, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_get_channels_2() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             num_channels: 2,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, 2, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_get_channels_too_many_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             num_channels: 3,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_error(result, "WrongNumChannels(3,2)");
     }
 
     #[test]
     fn test_circus_of_freaks_convert_to_mono_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             num_channels: 2,
             convert_to_mono: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, 1, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
     }
     #[test]
     fn test_circus_of_freaks_convert_to_mono_2() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             convert_to_mono: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, 1, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
     }
 
@@ -132,21 +132,21 @@ mod test_waveform_from_file {
         // In this test, we do mono and stereo decoding of an audio file
         // that only has audio in one of its two channels.
         // First, let's do the mono decoding.
-        let mono_decode_args = DecodeArgs {
+        let mono_waveform_args = WaveformArgs {
             convert_to_mono: true,
             ..Default::default()
         };
-        let mono_result = decode_lct_mp3(mono_decode_args);
+        let mono_result = decode_lct_mp3(mono_waveform_args);
         let mono_waveform = mono_result.unwrap();
         assert_eq!(1, mono_waveform.num_channels());
         assert_eq!(LCT_NUM_FRAMES, mono_waveform.num_frames());
         assert_eq!(LCT_FRAME_RATE_HZ, mono_waveform.frame_rate_hz());
         let mono_sum_waveform: f32 = mono_waveform.to_interleaved_samples().iter().sum();
         // Now, let's do the stereo decoding.
-        let stereo_decode_args = DecodeArgs {
+        let stereo_waveform_args = WaveformArgs {
             ..Default::default()
         };
-        let stereo_result = decode_lct_mp3(stereo_decode_args);
+        let stereo_result = decode_lct_mp3(stereo_waveform_args);
         let stereo_waveform = stereo_result.unwrap();
         assert_eq!(LCT_NUM_CHANNELS, stereo_waveform.num_channels());
         assert_eq!(LCT_NUM_FRAMES, stereo_waveform.num_frames());
@@ -164,384 +164,384 @@ mod test_waveform_from_file {
 
     #[test]
     fn test_circus_of_freaks_convert_to_mono_invalid_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             num_channels: 1,
             convert_to_mono: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_error(result, "WrongNumChannelsAndMono");
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 0,
             end_time_milliseconds: 1,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 44, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_2() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 10,
             end_time_milliseconds: 11,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 44, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_3() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 0,
             end_time_milliseconds: 30000,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_4() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 15000,
             end_time_milliseconds: 45000,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_5() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 30000,
             end_time_milliseconds: 60000,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 1168776, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_6() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 45000,
             end_time_milliseconds: 60000,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 507276, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 0,
             end_time_milliseconds: 1,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 44, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_2() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 10,
             end_time_milliseconds: 11,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 44, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_3() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 0,
             end_time_milliseconds: 30000,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_4() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 15000,
             end_time_milliseconds: 45000,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_5() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 30000,
             end_time_milliseconds: 60000,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 1323000, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_6() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 0,
             end_time_milliseconds: 60000,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 2646000, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_7() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 0,
             end_time_milliseconds: 90000,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 3969000, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_zero_pad_ending_8() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 30000,
             end_time_milliseconds: 90000,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 2646000, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_end_milliseconds_zero_pad_ending_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             end_time_milliseconds: 90000,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 3969000, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_invalid_resample_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 1,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_error(result, "WrongFrameRateRatio(44100,1)");
     }
 
     #[test]
     fn test_circus_of_freaks_invalid_resample_2() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 20,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_error(result, "WrongFrameRateRatio(44100,20)");
     }
 
     #[test]
     fn test_circus_of_freaks_invalid_resample_3() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 172,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_error(result, "WrongFrameRateRatio(44100,172)");
     }
 
     #[test]
     fn test_circus_of_freaks_resample_no_change_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: COF_FRAME_RATE_HZ,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, COF_NUM_FRAMES, COF_FRAME_RATE_HZ);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 22050,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 1245888, 22050);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_2() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 11025,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 622944, 11025);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_3() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 88200,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 4983552, 88200);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_4() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 4410,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 249178, 4410);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_5() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 44099,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 2491720, 44099);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_6() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 48000,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 2712138, 48000);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_7() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 60000,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 3390172, 60000);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_8() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 88200,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 4983552, 88200);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_9() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 96000,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 5424275, 96000);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_10() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 200,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 11301, 200);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_11() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 2000,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 113006, 2000);
     }
 
     #[test]
     fn test_circus_of_freaks_resample_12() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             frame_rate_hz: 173,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 9775, 173);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_1() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 0,
             end_time_milliseconds: 60000,
             frame_rate_hz: 48000,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 2880000, 48000);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_2() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 0,
             end_time_milliseconds: 60000,
             frame_rate_hz: 44099,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 2645940, 44099);
     }
 
     #[test]
     fn test_circus_of_freaks_start_end_milliseconds_resample_zero_pad_ending_3() {
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             start_time_milliseconds: 0,
             end_time_milliseconds: 60000,
             frame_rate_hz: 22050,
             zero_pad_ending: true,
             ..Default::default()
         };
-        let result = decode_cof_mp3(decode_args);
+        let result = decode_cof_mp3(waveform_args);
         assert_waveform(result, COF_NUM_CHANNELS, 1323000, 22050);
     }
 }

--- a/tests/test_waveform_from_many_files.rs
+++ b/tests/test_waveform_from_many_files.rs
@@ -2,14 +2,14 @@ mod fixtures;
 
 mod test_waveform_from_many_files {
     use crate::fixtures::*;
-    use babycat::{BatchArgs, DecodeArgs, Waveform};
+    use babycat::{BatchArgs, Waveform, WaveformArgs};
 
     #[test]
     fn test_all_same_file_1() {
         let filenames = &[COF_FILENAME, COF_FILENAME, COF_FILENAME];
-        let decode_args = Default::default();
+        let waveform_args = Default::default();
         let batch_args = Default::default();
-        let batch = Waveform::from_many_files(filenames, decode_args, batch_args);
+        let batch = Waveform::from_many_files(filenames, waveform_args, batch_args);
         for named_result in batch {
             let waveform = named_result.result.unwrap();
             assert_eq!(COF_NUM_CHANNELS, waveform.num_channels());
@@ -25,12 +25,12 @@ mod test_waveform_from_many_files {
     #[test]
     fn test_all_same_file_2() {
         let filenames = &[COF_FILENAME, COF_FILENAME, COF_FILENAME];
-        let decode_args = DecodeArgs {
+        let waveform_args = WaveformArgs {
             end_time_milliseconds: 15000,
             ..Default::default()
         };
         let batch_args = Default::default();
-        let batch = Waveform::from_many_files(filenames, decode_args, batch_args);
+        let batch = Waveform::from_many_files(filenames, waveform_args, batch_args);
         let num_frames = 661500;
         for named_result in batch {
             let waveform = named_result.result.unwrap();
@@ -47,12 +47,12 @@ mod test_waveform_from_many_files {
     #[test]
     fn test_all_same_file_single_threaded_1() {
         let filenames = &[COF_FILENAME, COF_FILENAME, COF_FILENAME];
-        let decode_args = Default::default();
+        let waveform_args = Default::default();
         let batch_args = BatchArgs {
             num_workers: 1,
             ..Default::default()
         };
-        let batch = Waveform::from_many_files(filenames, decode_args, batch_args);
+        let batch = Waveform::from_many_files(filenames, waveform_args, batch_args);
         for named_result in batch {
             let waveform = named_result.result.unwrap();
             assert_eq!(COF_NUM_CHANNELS, waveform.num_channels());
@@ -67,9 +67,9 @@ mod test_waveform_from_many_files {
 
     #[test]
     fn test_different_filenames_1() {
-        let decode_args = Default::default();
+        let waveform_args = Default::default();
         let batch_args = Default::default();
-        let batch = Waveform::from_many_files(ALL_FILENAMES, decode_args, batch_args);
+        let batch = Waveform::from_many_files(ALL_FILENAMES, waveform_args, batch_args);
         for (i, named_result) in batch.into_iter().enumerate() {
             let waveform = named_result.result.unwrap();
             assert_eq!(ALL_NUM_CHANNELS[i], waveform.num_channels());
@@ -85,9 +85,9 @@ mod test_waveform_from_many_files {
     #[test]
     fn test_file_not_found_error_1() {
         let filenames = &[COF_FILENAME, "asdfasdf"];
-        let decode_args = Default::default();
+        let waveform_args = Default::default();
         let batch_args = Default::default();
-        let batch = Waveform::from_many_files(filenames, decode_args, batch_args);
+        let batch = Waveform::from_many_files(filenames, waveform_args, batch_args);
         assert_eq!(batch.len(), 2);
         let first_result = batch[0].result.as_ref().unwrap();
         assert_eq!(COF_NUM_CHANNELS, first_result.num_channels());

--- a/tests/test_waveform_resample_method.rs
+++ b/tests/test_waveform_resample_method.rs
@@ -5,8 +5,8 @@ mod fixtures;
 mod test_waveform_resample_method {
     use crate::fixtures::*;
 
-    use babycat::DecodeArgs;
     use babycat::Waveform;
+    use babycat::WaveformArgs;
     use babycat::RESAMPLE_MODE_BABYCAT_LANCZOS;
     use babycat::RESAMPLE_MODE_BABYCAT_SINC;
     use babycat::RESAMPLE_MODE_LIBSAMPLERATE;
@@ -22,13 +22,13 @@ mod test_waveform_resample_method {
     fn decode_and_assert(
         test_name: &str,
         filename: &str,
-        decode_args: DecodeArgs,
+        waveform_args: WaveformArgs,
         frame_rate_hz: u32,
         expected_num_channels: u32,
         expected_num_frames: u64,
         expected_frame_rate_hz: u32,
     ) {
-        let waveform = Waveform::from_file(filename, decode_args).unwrap();
+        let waveform = Waveform::from_file(filename, waveform_args).unwrap();
         for &resample_mode in RESAMPLE_MODES {
             match waveform.resample_by_mode(frame_rate_hz, resample_mode) {
                 Ok(resampled) => {


### PR DESCRIPTION
This struct is about creating `Waveform` instances, not relating to the decoders in the `decode` module.