### PR TITLE
Add the `waveforms_from_files_to_numpy` function for faster batch decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ crate-type = ["rlib", "cdylib", "staticlib"]
 symphonia = { version = "0.4.0",  features = [ "aac", "flac", "mp3", "pcm", "isomp4", "wav", "ogg", "vorbis" ] }
 
 base64 = "0.13"
+ndarray = "0.15"
 float-cmp= "0.8"
 hound = "3.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ WHEEL_DIR ?= target/frontend-python
 MANYLINUX_WHEEL_DIR ?= target/frontend-python--manylinux
 VENV_PATH ?= venv
 CREATE_VENV_CMD ?= $(PYTHON) -m venv $(VENV_PATH)
-PYTHON_CODE_PATHS ?= ./tests-python ./docs/source/conf.py
+PYTHON_CODE_PATHS ?= ./benches-python ./tests-python ./docs/source/conf.py
 
 
 # These are the Rust files being tracked by Git.
@@ -551,8 +551,13 @@ bench-rust: .b/init-rust
 	CARGO_TARGET_DIR=target/frontend-rust $(CARGO) bench
 .PHONY: bench-rust
 
+## bench-python
+bench-python: .b/init-python .b/install-python-wheel
+	$(ACTIVATE_VENV_CMD) && pytest benches-python/*
+.PHONY: bench-python
+
 ## bench
-bench: bench-rust
+bench: bench-rust bench-python
 .PHONY: bench
 
 

--- a/benches-python/decoding_numpy_benchmark.py
+++ b/benches-python/decoding_numpy_benchmark.py
@@ -1,0 +1,86 @@
+"""
+Runs Python benchmarks that measure the fastest way to turn a batch of audio files
+into a Python list of NumPy arrays.
+
+Our Rust code is pretty fast, but sometimes we encounter significant slowdowns
+if we spend too much time trying to acquire the Python Global Interpreter Lock (GIL).
+
+Our function :py:func:`~babycat.batch.from_files_to_numpy` manages to create NumPy
+arrays without needing as much of the GIL as :py:func:`~babycat.batch.from_files`
+seems to.
+
+However, the  :py:func:`~babycat.batch.from_files_to_numpy` currently has a
+worse error-handling situation and is currently not recommended to be used
+against audio files where errors may be common.
+"""
+import unittest
+
+import pytest
+
+import babycat
+
+assert_equal = unittest.TestCase().assertEqual
+
+mark_benchmark = pytest.mark.benchmark(min_rounds=8, warmup=True, warmup_iterations=2)
+
+NUM_FILENAMES = 12
+
+FILENAMES = [
+    "./audio-for-tests/andreas-theme/track.mp3",
+    "./audio-for-tests/blippy-trance/track.mp3",
+    "./audio-for-tests/circus-of-freaks/track.mp3",
+    "./audio-for-tests/left-channel-tone/track.mp3",
+    "./audio-for-tests/mono-dtmf-tones/track.mp3",
+    "./audio-for-tests/on-hold-for-you/track.mp3",
+    "./audio-for-tests/tone-missing-sounds/track.mp3",
+    "./audio-for-tests/voxel-revolution/track.mp3",
+] * NUM_FILENAMES
+
+
+def assert_decoded(waveforms):
+    """Assert the output shapes of decoded waveforms."""
+    assert_equal(waveforms[0].shape, (9586944, 2))
+    assert_equal(waveforms[1].shape, (5293440, 2))
+    assert_equal(waveforms[2].shape, (2491776, 2))
+    assert_equal(waveforms[3].shape, (1324800, 2))
+    assert_equal(waveforms[4].shape, (442368, 1))
+    assert_equal(waveforms[5].shape, (9620352, 2))
+    assert_equal(waveforms[6].shape, (1324800, 1))
+    assert_equal(waveforms[7].shape, (5728896, 2))
+
+
+def no_convert():
+    """Decode waveforms into NumPy arrays by manipulating them in Python."""
+    babycat.batch.waveforms_from_files(FILENAMES)
+
+
+@mark_benchmark
+def test_no_convert(benchmark):
+    """Run the ``no_convert`` benchmark."""
+    benchmark(no_convert)
+
+
+def waveforms_from_files():
+    """Decode waveforms into NumPy arrays by manipulating them in Python."""
+    return [
+        nwr.waveform.to_numpy() for nwr in babycat.batch.waveforms_from_files(FILENAMES)
+    ]
+
+
+@mark_benchmark
+def test_waveforms_from_files(benchmark):
+    """Run the ``waveforms_from_files`` benchmark as a pytest unit test."""
+    waveforms = benchmark(waveforms_from_files)
+    assert_decoded(waveforms)
+
+
+def waveforms_from_files_to_numpy():
+    """Decode waveforms into NumPy arrays by manipulating them within Rust."""
+    return babycat.batch.waveforms_from_files_to_numpy(FILENAMES)
+
+
+@mark_benchmark
+def test_waveforms_from_files_to_numpy(benchmark):
+    """Run the ``waveforms_from_files_to_numpy`` benchmark as a pytest unit test."""
+    waveforms = benchmark(waveforms_from_files_to_numpy)
+    assert_decoded(waveforms)

--- a/docs/source/api/python/batch/index.rst
+++ b/docs/source/api/python/batch/index.rst
@@ -1,6 +1,14 @@
 babycat.batch
 =============
 
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   .waveforms_from_files() <waveforms_from_files>
+   .waveforms_from_files_to_numpy() <waveforms_from_files_to_numpy>
+
+
 .. py:module:: babycat.batch
 
 This submodule contains functions for decoding/demuxing multiple audio files in parallel.
@@ -9,7 +17,5 @@ not be slowed down by the  `Python Global Interpreter Lock (GIL) <https://realpy
 
 Decoding audio
 --------------
-.. toctree::
-   :maxdepth: 2
-
-   .waveforms_from_files() <waveforms_from_files>
+- :doc:`waveforms_from_files`: Uses multithreading in Rust to decode many audio files in parallel, returning :py:func:`~babycat.WaveformNamedResult` objects containing filenames, waveforms, and/or Python exceptions.
+- :doc:`waveforms_from_files_to_numpy`: Uses multithreading in Rust to decode many audio files in parallel, directly returning NumPy arrays.

--- a/docs/source/api/python/batch/waveforms_from_files_to_numpy.rst
+++ b/docs/source/api/python/batch/waveforms_from_files_to_numpy.rst
@@ -1,0 +1,4 @@
+babycat.batch.waveforms_from_files_to_numpy()
+=============================================
+
+.. automethod:: babycat.batch.waveforms_from_files_to_numpy

--- a/examples-python/batch_decode.py
+++ b/examples-python/batch_decode.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import logging
+import time
+
+import babycat
+
+FILENAMES = ["audio-for-tests/circus-of-freaks/track.mp3"] * 200
+
+def waveforms_from_files():
+    t1 = time.monotonic()
+    results = babycat.batch.waveforms_from_files(
+        filenames=FILENAMES
+    )
+    t2 = time.monotonic()
+    for result in results:
+        result.waveform.to_numpy()
+    t3 = time.monotonic()
+    print("waveforms_from_files t2:", t2 - t1)
+    print("waveforms_from_files total:", t3-t1)
+
+
+def waveforms_from_files_to_numpy():
+    t1 = time.monotonic()
+    results = babycat.batch.waveforms_from_files_to_numpy(
+        filenames=FILENAMES
+    )
+    t2 = time.monotonic()
+    t3 = time.monotonic()
+    print("waveforms_from_files t2:", t2 - t1)
+    print("waveforms_from_files total:", t3-t1)
+
+def main():
+    waveforms_from_files()
+    waveforms_from_files_to_numpy()
+
+if __name__ == "__main__":
+    main()

--- a/makefile-help.txt
+++ b/makefile-help.txt
@@ -167,6 +167,7 @@ doctest-rust
 
 -----------------------------------------------------------------------
 bench                           Run benchmarks.
+bench-python
 bench-rust
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,6 @@ pylint==2.7.4
 
 # type annotations
 mypy==0.812
+
+# helps us run benchmarks
+pytest-benchmark==3.4.1

--- a/src/backend/waveform.rs
+++ b/src/backend/waveform.rs
@@ -669,3 +669,11 @@ impl Waveform {
         &self.interleaved_samples
     }
 }
+
+#[allow(clippy::from_over_into)]
+impl Into<ndarray::Array2<f32>> for Waveform {
+    fn into(self) -> ndarray::Array2<f32> {
+        let shape = (self.num_frames as usize, self.num_channels as usize);
+        ndarray::Array::from_shape_vec(shape, self.interleaved_samples).unwrap()
+    }
+}

--- a/tests-python/test_batch_waveforms_from_files_to_numpy.py
+++ b/tests-python/test_batch_waveforms_from_files_to_numpy.py
@@ -1,0 +1,37 @@
+"""
+Test loading audio waveforms directly as NumPy arrays.
+
+This test suite is specific to Babycat's Python bindings.
+"""
+
+from fixtures import *
+
+import babycat
+
+ALL_SAME_FILENAMES = [COF_FILENAME, COF_FILENAME, COF_FILENAME]
+
+
+def test_all_same_file_1():
+    batch = babycat.batch.waveforms_from_files_to_numpy(ALL_SAME_FILENAMES)
+    for arr in batch:
+        assert arr.shape[0] == COF_NUM_FRAMES
+        assert arr.shape[1] == COF_NUM_CHANNELS
+
+
+def test_all_same_file_2():
+    batch = babycat.batch.waveforms_from_files_to_numpy(
+        ALL_SAME_FILENAMES, end_time_milliseconds=15000
+    )
+    for arr in batch:
+        assert arr.shape[0] == 661500
+        assert arr.shape[1] == COF_NUM_CHANNELS
+
+
+def test_all_same_file_single_threaded_1():
+    batch = babycat.batch.waveforms_from_files_to_numpy(
+        ALL_SAME_FILENAMES,
+        num_workers=1,
+    )
+    for arr in batch:
+        assert arr.shape[0] == COF_NUM_FRAMES
+        assert arr.shape[1] == COF_NUM_CHANNELS

--- a/tests-python/test_doctests.py
+++ b/tests-python/test_doctests.py
@@ -31,3 +31,11 @@ def test_waveform_from_file():
 
 def test_batch():
     run_doctest(babycat.batch)
+
+
+def test_batch_waveforms_from_files():
+    run_doctest(babycat.batch.waveforms_from_files)
+
+
+def test_batch_waveforms_from_files_to_numpy():
+    run_doctest(babycat.batch.waveforms_from_files_to_numpy)


### PR DESCRIPTION
This method returns batches of waveforms as a Python list of
NumPy arrays. This should be significantly faster than
calling `.numpy()` on individual `Waveform` objects.