### PR TITLE
Use the `#[inline]` macro on resampling functions

### DIFF
--- a/src/backend/resample/babycat_lanczos.rs
+++ b/src/backend/resample/babycat_lanczos.rs
@@ -13,6 +13,7 @@ use std::f32::consts::PI;
 
 const KERNEL_A: i32 = 5;
 
+#[inline(always)]
 fn lanczos_kernel(x: f32, a: f32) -> f32 {
     if float_cmp::approx_eq!(f32, x, 0.0_f32) {
         return 1.0;
@@ -23,6 +24,7 @@ fn lanczos_kernel(x: f32, a: f32) -> f32 {
     0.0
 }
 
+#[inline(always)]
 fn compute_sample(
     input_audio: &[f32],
     frame_idx: f32,
@@ -44,6 +46,7 @@ fn compute_sample(
     the_sample
 }
 
+#[inline(always)]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,

--- a/src/backend/resample/babycat_lanczos.rs
+++ b/src/backend/resample/babycat_lanczos.rs
@@ -13,7 +13,7 @@ use std::f32::consts::PI;
 
 const KERNEL_A: i32 = 5;
 
-#[inline(always)]
+#[inline]
 fn lanczos_kernel(x: f32, a: f32) -> f32 {
     if float_cmp::approx_eq!(f32, x, 0.0_f32) {
         return 1.0;
@@ -24,7 +24,7 @@ fn lanczos_kernel(x: f32, a: f32) -> f32 {
     0.0
 }
 
-#[inline(always)]
+#[inline]
 fn compute_sample(
     input_audio: &[f32],
     frame_idx: f32,
@@ -46,7 +46,7 @@ fn compute_sample(
     the_sample
 }
 
-#[inline(always)]
+#[inline]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,

--- a/src/backend/resample/babycat_sinc.rs
+++ b/src/backend/resample/babycat_sinc.rs
@@ -13,7 +13,7 @@ use crate::backend::{
 #[allow(clippy::excessive_precision)]
 const KAISER_BEST_WINDOW: [f32; 32769] = include!("kaiser_best.txt");
 
-#[inline(always)]
+#[inline]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,
@@ -61,7 +61,7 @@ pub fn resample(
     Ok(ret)
 }
 
-#[inline(always)]
+#[inline]
 fn resample_f(
     in_audio: &[f32],
     out_audio: &mut [f32],

--- a/src/backend/resample/babycat_sinc.rs
+++ b/src/backend/resample/babycat_sinc.rs
@@ -13,6 +13,7 @@ use crate::backend::{
 #[allow(clippy::excessive_precision)]
 const KAISER_BEST_WINDOW: [f32; 32769] = include!("kaiser_best.txt");
 
+#[inline(always)]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,
@@ -60,6 +61,7 @@ pub fn resample(
     Ok(ret)
 }
 
+#[inline(always)]
 fn resample_f(
     in_audio: &[f32],
     out_audio: &mut [f32],

--- a/src/backend/resample/common.rs
+++ b/src/backend/resample/common.rs
@@ -7,10 +7,12 @@
 
 use crate::backend::errors::Error;
 
+#[inline(always)]
 pub fn get<T: Copy>(v: &[T], frame: usize, channel_idx: usize, num_channels: usize) -> T {
     v[frame * num_channels + channel_idx]
 }
 
+#[inline(always)]
 pub fn validate_args(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,
@@ -42,6 +44,7 @@ pub fn validate_args(
     Ok(())
 }
 
+#[inline(always)]
 pub fn get_num_output_frames(
     input_audio: &[f32],
     input_frame_rate_hz: u32,

--- a/src/backend/resample/common.rs
+++ b/src/backend/resample/common.rs
@@ -7,12 +7,12 @@
 
 use crate::backend::errors::Error;
 
-#[inline(always)]
+#[inline]
 pub fn get<T: Copy>(v: &[T], frame: usize, channel_idx: usize, num_channels: usize) -> T {
     v[frame * num_channels + channel_idx]
 }
 
-#[inline(always)]
+#[inline]
 pub fn validate_args(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,
@@ -44,7 +44,7 @@ pub fn validate_args(
     Ok(())
 }
 
-#[inline(always)]
+#[inline]
 pub fn get_num_output_frames(
     input_audio: &[f32],
     input_frame_rate_hz: u32,

--- a/src/backend/resample/libsamplerate.rs
+++ b/src/backend/resample/libsamplerate.rs
@@ -18,6 +18,7 @@ use crate::backend::resample::common::validate_args;
 /// for the WebAssembly frontend.
 ///
 #[allow(unused_variables)]
+#[inline(always)]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,

--- a/src/backend/resample/libsamplerate.rs
+++ b/src/backend/resample/libsamplerate.rs
@@ -18,7 +18,7 @@ use crate::backend::resample::common::validate_args;
 /// for the WebAssembly frontend.
 ///
 #[allow(unused_variables)]
-#[inline(always)]
+#[inline]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,

--- a/src/backend/resample/mod.rs
+++ b/src/backend/resample/mod.rs
@@ -16,6 +16,7 @@ use crate::backend::waveform_args::RESAMPLE_MODE_BABYCAT_LANCZOS;
 use crate::backend::waveform_args::RESAMPLE_MODE_BABYCAT_SINC;
 use crate::backend::waveform_args::RESAMPLE_MODE_LIBSAMPLERATE;
 
+#[inline(always)]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,

--- a/src/backend/resample/mod.rs
+++ b/src/backend/resample/mod.rs
@@ -16,7 +16,7 @@ use crate::backend::waveform_args::RESAMPLE_MODE_BABYCAT_LANCZOS;
 use crate::backend::waveform_args::RESAMPLE_MODE_BABYCAT_SINC;
 use crate::backend::waveform_args::RESAMPLE_MODE_LIBSAMPLERATE;
 
-#[inline(always)]
+#[inline]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,


### PR DESCRIPTION
This should provide us a small performance boost when resampling
audio.