### PR TITLE
Add Docker container to build Python manylinux frontend with FFmpeg

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ babycat.h
 **/Cargo.lock
 CODE_OF_CONDUCT.md
 makefile-help.md
+docker
 docs/_build
 **/node_modules
 **/package-lock.json

--- a/.github/workflows/test-python-ffmeg-manylinux.yml
+++ b/.github/workflows/test-python-ffmeg-manylinux.yml
@@ -1,0 +1,28 @@
+# Run the tests for the Python manylinux wheel with FFmpeg enabled.
+name: test-python-ffmpeg-manylinux
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    tags-ignore:
+      - 'v*' # Don't run these tests twice when cutting a new version.
+
+jobs:
+  test-python-ffmpeg-manylinux:
+    runs-on: "ubuntu-20.04"
+
+    steps:
+
+    - name: Check out Babycat code from GitHub
+      uses: actions/checkout@v2
+
+    - name: Build the manylinux Python frontend with FFmpeg
+      run: make build-python-ffmpeg-manylinux
+
+    - name: Run Python tests
+      run: make test-python-ffmpeg-manylinux

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,23 @@ services:
         source: "."
         target: /io
 
+  # A container used to build a manylinux wheel for Babycat's
+  # Python frontend--with FFmpeg enabled.
+  babycat-python-ffmpeg-manylinux:
+    build:
+      network: host
+      context: .
+      dockerfile: ./docker/babycat-python-ffmpeg-manylinux/Dockerfile
+    image: babycat/babycat-python-ffmpeg-manylinux
+    init: true
+    network_mode: host
+    entrypoint: bash
+    working_dir: /io
+    volumes:
+      - type: bind
+        source: "."
+        target: /io
+
   # A local copy of the Netlify build image.
   # Used to test the `make docs-netlify` build command.
   netlify:

--- a/docker/babycat-python-ffmpeg-manylinux/Dockerfile
+++ b/docker/babycat-python-ffmpeg-manylinux/Dockerfile
@@ -1,0 +1,72 @@
+ARG PYTHON=python3.6
+ARG ENABLE_FFMPEG_BUILD_LINK_STATIC=1
+ARG DISABLE_VENV=1
+ARG WHEEL_DIR=/wheels
+
+
+
+# =========================================================
+FROM quay.io/pypa/manylinux2014_x86_64 AS manylinux_stage
+
+# Silence interactivity.
+ENV DEBIAN_FRONTEND noninteractive
+
+# Set up the paths to the various Python installations.
+ENV PATH /opt/python/cp36-cp36m/bin/:/opt/python/cp37-cp37m/bin/:/opt/python/cp38-cp38/bin/:/opt/python/cp39-cp39/bin/:${PATH}
+
+# Set up directories and permissions.
+RUN mkdir /.cache /.local /wheels /babycat && chmod --recursive 777 /.cache /wheels /babycat
+WORKDIR /babycat
+
+
+
+# =========================================================
+FROM manylinux_stage AS build_stage
+ARG PYTHON
+ARG ENABLE_FFMPEG_BUILD_LINK_STATIC
+ARG DISABLE_VENV
+ARG WHEEL_DIR
+
+# Install Rust.
+COPY --from=rust:1.56.0-slim /usr/local/cargo /usr/local/cargo
+COPY --from=rust:1.56.0-slim /usr/local/rustup /usr/local/rustup
+RUN chmod --recursive 777 /usr/local/cargo /usr/local/rustup
+ENV PATH /usr/local/cargo/bin:${PATH}
+ENV RUST_ARCH x86_64-unknown-linux-gnu
+ENV CARGO_HOME /usr/local/cargo
+ENV RUSTUP_HOME /usr/local/cargo
+RUN rustup default 1.56.0-${RUST_ARCH}
+
+# Install libclang and other tools that are required for building FFmpeg.
+RUN yum update -y \
+    && yum install -y centos-release-scl \
+    && yum install -y llvm-toolset-7
+
+# Vendor Rust dependencies
+COPY Cargo.toml Makefile .listfiles.py ./
+COPY .cargo .cargo
+RUN mkdir .b src && touch src/lib.rs
+RUN make vendor
+
+# Install Maturin and any other Python dependencies that we need to build Babycat.
+COPY requirements-build.txt .
+RUN make init-python-requirements-build
+
+# Build FFmpeg, Babycat, and Babycat's Python bindings.
+COPY . .
+RUN scl enable llvm-toolset-7 'make build-python'
+
+
+
+# =========================================================
+# Start over in a fresh container that doesn't have clang.
+FROM manylinux_stage AS run_stage
+ARG PYTHON
+
+# Install dependencies for running tests.
+COPY --from=build_stage /babycat/requirements-dev.txt .
+RUN ${PYTHON} -m pip install -r requirements-dev.txt
+
+# Install our compiled wheel from the previous container.
+COPY --from=build_stage /wheels /wheels
+RUN ${PYTHON} -m pip install /wheels/*

--- a/docker/pip/Dockerfile
+++ b/docker/pip/Dockerfile
@@ -1,10 +1,17 @@
 # Use a Docker container to build the manylinux wheel.
 FROM quay.io/pypa/manylinux2014_x86_64
 
+ENV DEBIAN_FRONTEND noninteractive
+
+# Fix permissions issues with our pip cache.
+RUN mkdir /.cache && chmod --recursive 777 /.cache
+
+
 # Install Rust so we can build the wheel.
 COPY --from=rust:1.56.0-slim /usr/local/cargo /usr/local/cargo
 COPY --from=rust:1.56.0-slim /usr/local/rustup /usr/local/rustup
 RUN chmod --recursive 777 /usr/local/cargo /usr/local/rustup
+
 
 # Configure our build environment.
 ENV PATH /usr/local/cargo/bin:/opt/python/cp36-cp36m/bin/:/opt/python/cp37-cp37m/bin/:/opt/python/cp38-cp38/bin/:/opt/python/cp39-cp39/bin/:${PATH}


### PR DESCRIPTION
This Docker container builds and statically links to FFmpeg
(and its dependencies) while only dynamically linking to
the whitelist of C/C++ libraries that are compatible
wtih the Python manylinux standard.