### PR TITLE
Create a `Signal` trait for describing frame rates and channels

### DIFF
--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,4 +1,4 @@
-use babycat::{Waveform, WaveformArgs};
+use babycat::{Signal, Waveform, WaveformArgs};
 
 fn main() {
     let waveform_args = WaveformArgs {

--- a/src/backend/decode/decoder.rs
+++ b/src/backend/decode/decoder.rs
@@ -1,13 +1,8 @@
 use crate::backend::decode::decoder_iter::DecoderIter;
 use crate::backend::errors::Error;
+use crate::backend::signal::Signal;
 
 /// Methods common to all audio decoders.
-pub trait Decoder {
+pub trait Decoder: Signal {
     fn begin(&mut self) -> Result<Box<dyn DecoderIter + '_>, Error>;
-
-    fn frame_rate_hz(&self) -> u32;
-
-    fn num_channels(&self) -> u16;
-
-    fn num_frames_estimate(&self) -> Option<usize>;
 }

--- a/src/backend/decode/decoder_iter.rs
+++ b/src/backend/decode/decoder_iter.rs
@@ -1,2 +1,4 @@
+use crate::backend::signal::Signal;
+
 /// A sample iterator created by an audio decoder.
-pub trait DecoderIter: Iterator<Item = f32> {}
+pub trait DecoderIter: Signal + Iterator<Item = f32> {}

--- a/src/backend/decode/ffmpeg/decoder_iter.rs
+++ b/src/backend/decode/ffmpeg/decoder_iter.rs
@@ -5,6 +5,7 @@ use ffmpeg::format::context::Input;
 
 use crate::backend::decode::decoder_iter::DecoderIter;
 use crate::backend::decode::ffmpeg::frame_iter::FrameIter;
+use crate::backend::signal::Signal;
 
 #[inline(always)]
 fn next_packet<'a>(
@@ -24,6 +25,9 @@ pub struct FFmpegDecoderIter<'a> {
     decoder: &'a mut AudioDecoder,
     packet_iter: PacketIter<'a>,
     stream_index: usize,
+    frame_rate_hz: u32,
+    num_channels: u16,
+    est_num_frames: Option<usize>,
     packet: Option<Packet>,
     frame: Option<FrameIter>,
     sent_eof: bool,
@@ -31,7 +35,14 @@ pub struct FFmpegDecoderIter<'a> {
 }
 
 impl<'a> FFmpegDecoderIter<'a> {
-    pub fn new(input: &'a mut Input, decoder: &'a mut AudioDecoder, stream_index: usize) -> Self {
+    pub fn new(
+        input: &'a mut Input,
+        decoder: &'a mut AudioDecoder,
+        stream_index: usize,
+        frame_rate_hz: u32,
+        num_channels: u16,
+        est_num_frames: Option<usize>,
+    ) -> Self {
         let mut packet_iter = input.packets();
         let packet = next_packet(&mut packet_iter, decoder, stream_index);
         let frame = FrameIter::new(decoder);
@@ -39,6 +50,9 @@ impl<'a> FFmpegDecoderIter<'a> {
             decoder,
             packet_iter,
             stream_index,
+            frame_rate_hz,
+            num_channels,
+            est_num_frames,
             packet,
             frame,
             sent_eof: false,
@@ -48,6 +62,23 @@ impl<'a> FFmpegDecoderIter<'a> {
 }
 
 impl<'a> DecoderIter for FFmpegDecoderIter<'a> {}
+
+impl<'a> Signal for FFmpegDecoderIter<'a> {
+    #[inline(always)]
+    fn frame_rate_hz(&self) -> u32 {
+        self.frame_rate_hz
+    }
+
+    #[inline(always)]
+    fn num_channels(&self) -> u16 {
+        self.num_channels
+    }
+
+    #[inline(always)]
+    fn num_frames_estimate(&self) -> Option<usize> {
+        self.est_num_frames
+    }
+}
 
 impl<'a> Iterator for FFmpegDecoderIter<'a> {
     type Item = f32;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -8,12 +8,14 @@ mod common;
 pub mod decode;
 mod errors;
 pub mod resample;
+mod signal;
 mod waveform;
 mod waveform_args;
 mod waveform_named_result;
 mod waveform_result;
 
 pub use errors::*;
+pub use signal::Signal;
 pub use waveform::*;
 pub use waveform_args::*;
 pub use waveform_named_result::WaveformNamedResult;

--- a/src/backend/signal.rs
+++ b/src/backend/signal.rs
@@ -1,0 +1,7 @@
+pub trait Signal {
+    fn frame_rate_hz(&self) -> u32;
+
+    fn num_channels(&self) -> u16;
+
+    fn num_frames_estimate(&self) -> Option<usize>;
+}

--- a/src/backend/waveform.rs
+++ b/src/backend/waveform.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::backend::common::milliseconds_to_frames;
 use crate::backend::errors::Error;
 use crate::backend::resample::resample;
+use crate::backend::signal::Signal;
 use crate::backend::waveform_args::*;
 
 use crate::backend::decode::decoder::Decoder;
@@ -35,9 +36,7 @@ impl fmt::Debug for Waveform {
         write!(
             f,
             "Waveform {{ frame_rate_hz: {}, num_channels: {}, num_frames: {}}}",
-            self.frame_rate_hz(),
-            self.num_channels(),
-            self.num_frames()
+            self.frame_rate_hz, self.num_channels, self.num_frames
         )
     }
 }
@@ -605,16 +604,6 @@ impl Waveform {
         }
     }
 
-    /// Returns the frame rate of the `Waveform`.
-    pub fn frame_rate_hz(&self) -> u32 {
-        self.frame_rate_hz
-    }
-
-    /// Returns the number of channels in the `Waveform`.
-    pub fn num_channels(&self) -> u16 {
-        self.num_channels
-    }
-
     /// Returns the total number of decoded frames in the `Waveform`.
     pub fn num_frames(&self) -> usize {
         self.num_frames
@@ -623,6 +612,22 @@ impl Waveform {
     /// Returns the waveform as a slice of channel-interleaved `f32` samples.
     pub fn to_interleaved_samples(&self) -> &[f32] {
         &self.interleaved_samples
+    }
+}
+
+impl Signal for Waveform {
+    /// Returns the frame rate of the `Waveform`.
+    fn frame_rate_hz(&self) -> u32 {
+        self.frame_rate_hz
+    }
+
+    /// Returns the number of channels in the `Waveform`.
+    fn num_channels(&self) -> u16 {
+        self.num_channels
+    }
+
+    fn num_frames_estimate(&self) -> Option<usize> {
+        Some(self.num_frames)
     }
 }
 
@@ -643,6 +648,7 @@ mod test_waveform_from_file_ffmpeg {
     const TTCT_FRAME_RATE_HZ: u32 = 44100;
 
     use crate::Error;
+    use crate::Signal;
     use crate::Waveform;
     use crate::WaveformArgs;
     use crate::DECODING_BACKEND_FFMPEG;

--- a/src/bin/babycat/commands/convert.rs
+++ b/src/bin/babycat/commands/convert.rs
@@ -1,5 +1,6 @@
 use log::info;
 
+use babycat::Signal;
 use babycat::Waveform;
 use babycat::WaveformArgs;
 use babycat::DECODING_BACKEND_SYMPHONIA;

--- a/src/bin/babycat/commands/play.rs
+++ b/src/bin/babycat/commands/play.rs
@@ -9,6 +9,7 @@ use crossterm::terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType, S
 use rodio::Sample;
 use rodio::Source;
 
+use babycat::Signal;
 use babycat::Waveform;
 
 const NANOSECONDS_PER_SECOND: usize = 1000000000;

--- a/src/frontends/c.rs
+++ b/src/frontends/c.rs
@@ -1,4 +1,5 @@
 use crate::backend::Error;
+use crate::backend::Signal;
 use crate::backend::Waveform;
 use crate::backend::WaveformArgs;
 use std::ffi::CStr;

--- a/src/frontends/python/waveform.rs
+++ b/src/frontends/python/waveform.rs
@@ -3,6 +3,8 @@ use pyo3::prelude::*;
 use pyo3::types::PyByteArray;
 use pyo3::PyObjectProtocol;
 
+use crate::backend::Signal;
+
 impl From<crate::backend::Waveform> for Py<PyArray2<f32>> {
     fn from(waveform: crate::backend::Waveform) -> Py<PyArray2<f32>> {
         let num_frames: usize = waveform.num_frames();

--- a/src/frontends/wasm.rs
+++ b/src/frontends/wasm.rs
@@ -4,6 +4,8 @@ use js_sys::Float32Array;
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 
+use crate::backend::Signal;
+
 fn throw_js_error<E: std::fmt::Display>(err: E) -> JsValue {
     let err_string: String = err.to_string();
     js_sys::Error::new(&err_string).into()

--- a/tests/test_waveform_batch_different_encodings.rs
+++ b/tests/test_waveform_batch_different_encodings.rs
@@ -4,6 +4,7 @@
 
 mod test_waveform_different_encodings {
     use babycat::batch::waveforms_from_files;
+    use babycat::Signal;
     // I am not certain why the same audio file encoded as MP3, WAV, or FLAC
     // ends up with significantly different numbers of samples.
     // The values for num_frames() in unit tests like these might have to change

--- a/tests/test_waveform_batch_from_files.rs
+++ b/tests/test_waveform_batch_from_files.rs
@@ -3,6 +3,7 @@ mod fixtures;
 mod test_waveform_batch_from_files {
     use crate::fixtures::*;
     use babycat::batch::{waveforms_from_files, BatchArgs};
+    use babycat::Signal;
     use babycat::WaveformArgs;
 
     #[test]

--- a/tests/test_waveform_from_encoded_bytes.rs
+++ b/tests/test_waveform_from_encoded_bytes.rs
@@ -2,6 +2,7 @@ mod fixtures;
 
 mod test_waveform_from_encoded_bytes {
     use crate::fixtures::*;
+    use babycat::Signal;
     use babycat::Waveform;
 
     #[test]

--- a/tests/test_waveform_from_encoded_stream.rs
+++ b/tests/test_waveform_from_encoded_stream.rs
@@ -2,6 +2,7 @@ mod fixtures;
 
 mod test_waveform_from_encoded_stream {
     use crate::fixtures::*;
+    use babycat::Signal;
     use babycat::Waveform;
     use std::io::Cursor;
 

--- a/tests/test_waveform_from_file.rs
+++ b/tests/test_waveform_from_file.rs
@@ -3,6 +3,7 @@ mod fixtures;
 mod test_waveform_from_file {
     use crate::fixtures::*;
     use babycat::Error;
+    use babycat::Signal;
     use babycat::Waveform;
     use babycat::WaveformArgs;
 

--- a/tests/test_waveform_from_interleaved_samples.rs
+++ b/tests/test_waveform_from_interleaved_samples.rs
@@ -1,4 +1,5 @@
 mod test_waveform_from_interleaved_samples {
+    use babycat::Signal;
     use babycat::Waveform;
 
     #[test]

--- a/tests/test_waveform_resample_method.rs
+++ b/tests/test_waveform_resample_method.rs
@@ -5,6 +5,7 @@ mod fixtures;
 mod test_waveform_resample_method {
     use crate::fixtures::*;
 
+    use babycat::Signal;
     use babycat::Waveform;
     use babycat::WaveformArgs;
     use babycat::RESAMPLE_MODE_BABYCAT_LANCZOS;


### PR DESCRIPTION
This new `Signal` trait implements a common interface for querying a signal's frame rate, channels, and and estimate of how long it is.

The exact methods are:

* `fn frame_rate_hz(&self) -> u32`
* `fn num_channels(&self) -> u16`
* `fn num_frames_estimate(&self) -> Option<usize>`