### PR TITLE
Create bounded wrapper Iterators for audio decoding

### DIFF
--- a/src/backend/decode/convert_to_mono_decoder_iter.rs
+++ b/src/backend/decode/convert_to_mono_decoder_iter.rs
@@ -1,0 +1,72 @@
+use crate::backend::decode::decoder_iter::DecoderIter;
+use crate::backend::signal::Signal;
+
+pub struct ConvertToMonoDecoderIter<D: DecoderIter> {
+    iter: D,
+    disabled: bool,
+    iter_num_channels_usize: usize,
+    iter_num_channels_f32: f32,
+}
+
+impl<D: DecoderIter> ConvertToMonoDecoderIter<D> {
+    #[inline(always)]
+    pub fn new(iter: D, enabled: bool) -> Self {
+        let iter_num_channels_usize: usize = iter.num_channels() as usize;
+        let iter_num_channels_f32: f32 = iter_num_channels_usize as f32;
+        Self {
+            iter,
+            disabled: !enabled,
+            iter_num_channels_usize,
+            iter_num_channels_f32,
+        }
+    }
+}
+
+impl<D: DecoderIter> DecoderIter for ConvertToMonoDecoderIter<D> {}
+
+impl<D: DecoderIter> Signal for ConvertToMonoDecoderIter<D> {
+    #[inline(always)]
+    fn frame_rate_hz(&self) -> u32 {
+        self.iter.frame_rate_hz()
+    }
+
+    #[inline(always)]
+    fn num_channels(&self) -> u16 {
+        1
+    }
+
+    #[inline(always)]
+    fn num_frames_estimate(&self) -> Option<usize> {
+        self.iter.num_frames_estimate()
+    }
+}
+
+impl<D: DecoderIter> Iterator for ConvertToMonoDecoderIter<D> {
+    type Item = f32;
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.iter.size_hint() {
+            (min, None) => (min / self.iter_num_channels_usize, None),
+            (min, Some(max)) => (
+                min / self.iter_num_channels_usize,
+                Some(max / self.iter_num_channels_usize),
+            ),
+        }
+    }
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.disabled {
+            return self.iter.next();
+        }
+        let mut psum: f32 = 0.0_f32;
+        for _ in 0..self.iter_num_channels_usize {
+            match self.iter.next() {
+                None => return None,
+                Some(val) => psum += val,
+            }
+        }
+        Some(psum / self.iter_num_channels_f32)
+    }
+}

--- a/src/backend/decode/decoder.rs
+++ b/src/backend/decode/decoder.rs
@@ -6,3 +6,27 @@ use crate::backend::signal::Signal;
 pub trait Decoder: Signal {
     fn begin(&mut self) -> Result<Box<dyn DecoderIter + '_>, Error>;
 }
+
+impl Decoder for Box<dyn Decoder> {
+    #[inline(always)]
+    fn begin(&mut self) -> Result<Box<dyn DecoderIter + '_>, Error> {
+        (&mut **self).begin()
+    }
+}
+
+impl Signal for Box<dyn Decoder> {
+    #[inline(always)]
+    fn frame_rate_hz(&self) -> u32 {
+        (&**self).frame_rate_hz()
+    }
+
+    #[inline(always)]
+    fn num_channels(&self) -> u16 {
+        (&**self).num_channels()
+    }
+
+    #[inline(always)]
+    fn num_frames_estimate(&self) -> Option<usize> {
+        (&**self).num_frames_estimate()
+    }
+}

--- a/src/backend/decode/decoder_iter.rs
+++ b/src/backend/decode/decoder_iter.rs
@@ -1,4 +1,60 @@
 use crate::backend::signal::Signal;
 
+use crate::backend::decode::convert_to_mono_decoder_iter::ConvertToMonoDecoderIter;
+use crate::backend::decode::select_channels_decoder_iter::SelectChannelsDecoderIter;
+use crate::backend::decode::skip_samples_decoder_iter::SkipSamplesDecoderIter;
+use crate::backend::decode::take_samples_decoder_iter::TakeSamplesDecoderIter;
+
 /// A sample iterator created by an audio decoder.
-pub trait DecoderIter: Signal + Iterator<Item = f32> {}
+pub trait DecoderIter: Signal + Iterator<Item = f32> {
+    #[inline(always)]
+    fn skip_samples(self, count: usize) -> SkipSamplesDecoderIter<Self>
+    where
+        Self: Sized,
+    {
+        SkipSamplesDecoderIter::new(self, count)
+    }
+
+    #[inline(always)]
+    fn take_samples(self, count: usize) -> TakeSamplesDecoderIter<Self>
+    where
+        Self: Sized,
+    {
+        TakeSamplesDecoderIter::new(self, count)
+    }
+
+    #[inline(always)]
+    fn select_first_channels(self, selected_num_channels: u16) -> SelectChannelsDecoderIter<Self>
+    where
+        Self: Sized,
+    {
+        SelectChannelsDecoderIter::new(self, selected_num_channels)
+    }
+
+    #[inline(always)]
+    fn convert_to_mono(self, enabled: bool) -> ConvertToMonoDecoderIter<Self>
+    where
+        Self: Sized,
+    {
+        ConvertToMonoDecoderIter::new(self, enabled)
+    }
+}
+
+impl DecoderIter for Box<dyn DecoderIter + '_> {}
+
+impl Signal for Box<dyn DecoderIter + '_> {
+    #[inline(always)]
+    fn frame_rate_hz(&self) -> u32 {
+        (&**self).frame_rate_hz()
+    }
+
+    #[inline(always)]
+    fn num_channels(&self) -> u16 {
+        (&**self).num_channels()
+    }
+
+    #[inline(always)]
+    fn num_frames_estimate(&self) -> Option<usize> {
+        (&**self).num_frames_estimate()
+    }
+}

--- a/src/backend/decode/ffmpeg/decoder_iter.rs
+++ b/src/backend/decode/ffmpeg/decoder_iter.rs
@@ -130,12 +130,36 @@ impl<'a, T: Sample, const PACKED: bool> Signal for FFmpegDecoderIter<'a, T, PACK
 
     #[inline(always)]
     fn num_frames_estimate(&self) -> Option<usize> {
-        self.est_num_frames
+        match self.est_num_frames {
+            None => None,
+            Some(est_num_frames) => {
+                if self.frame_idx >= est_num_frames {
+                    return None;
+                }
+                Some(est_num_frames - self.frame_idx)
+            }
+        }
     }
 }
 
 impl<'a, T: Sample, const PACKED: bool> Iterator for FFmpegDecoderIter<'a, T, PACKED> {
     type Item = f32;
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.est_num_frames {
+            None => (0, None),
+            Some(est_num_frames) => {
+                let est_num_samples = est_num_frames * self.num_channels_usize;
+                let current_sample_idx: usize =
+                    self.frame_idx * self.num_channels_usize + self.channel_idx;
+                if current_sample_idx >= est_num_samples {
+                    return (0, None);
+                }
+                (est_num_samples - current_sample_idx, None)
+            }
+        }
+    }
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -189,5 +213,56 @@ impl<'a, T: Sample, const PACKED: bool> Iterator for FFmpegDecoderIter<'a, T, PA
                 }
             }
         }
+    }
+}
+
+#[cfg(all(test, feature = "enable-ffmpeg"))]
+mod test_ffmpeg_decoder_iter {
+    use crate::decode::FFmpegDecoder;
+
+    pub const COF_FILENAME: &str = "./audio-for-tests/circus-of-freaks/track.flac";
+    pub const COF_NUM_CHANNELS: u16 = 2;
+    pub const COF_NUM_FRAMES: usize = 2491247;
+    pub const COF_NUM_SAMPLES: usize = COF_NUM_FRAMES * COF_NUM_CHANNELS as usize;
+
+    pub const MONO_DTMF_FILENAME: &str = "./audio-for-tests/mono-dtmf-tones/track.flac";
+    pub const MONO_DTMF_NUM_CHANNELS: u16 = 1;
+    pub const MONO_DTMF_NUM_FRAMES: usize = 441000;
+    pub const MONO_DTMF_SAMPLES: usize = MONO_DTMF_NUM_FRAMES * MONO_DTMF_NUM_CHANNELS as usize;
+
+    #[test]
+    fn test_cof_size_hint_1() {
+        let mut decoder =
+            FFmpegDecoder::from_file(COF_FILENAME).expect("Failed to decode circus-of-freaks");
+        let mut decoder_iter = decoder.begin().expect("Failed to create DecoderIter");
+        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES, None));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES - 1, None));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES - 2, None));
+        let decoder_iter = decoder_iter.skip(10);
+        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES - 12, None));
+        let mut decoder_iter = decoder_iter.take(1000);
+        assert_eq!(decoder_iter.size_hint(), (1000, Some(1000)));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (999, Some(999)));
+    }
+
+    #[test]
+    fn test_mono_dtmf_size_hint_1() {
+        let mut decoder =
+            FFmpegDecoder::from_file(MONO_DTMF_FILENAME).expect("Failed to decode mono-dtmf-tones");
+        let mut decoder_iter = decoder.begin().expect("Failed to create DecoderIter");
+        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES, None));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES - 1, None));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES - 2, None));
+        let decoder_iter = decoder_iter.skip(10);
+        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES - 12, None));
+        let mut decoder_iter = decoder_iter.take(1000);
+        assert_eq!(decoder_iter.size_hint(), (1000, Some(1000)));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (999, Some(999)));
     }
 }

--- a/src/backend/decode/mod.rs
+++ b/src/backend/decode/mod.rs
@@ -1,12 +1,21 @@
 pub mod boxed_decoder;
+mod convert_to_mono_decoder_iter;
 pub mod decoder;
 pub mod decoder_iter;
+mod select_channels_decoder_iter;
+mod skip_samples_decoder_iter;
 pub mod symphonia;
+mod take_samples_decoder_iter;
 
 pub use crate::backend::decode::decoder::Decoder;
 pub use crate::backend::decode::decoder_iter::DecoderIter;
 pub use crate::backend::decode::symphonia::decoder::SymphoniaDecoder;
 pub use crate::backend::decode::symphonia::decoder_iter::SymphoniaDecoderIter;
+
+pub use convert_to_mono_decoder_iter::ConvertToMonoDecoderIter;
+pub use select_channels_decoder_iter::SelectChannelsDecoderIter;
+pub use skip_samples_decoder_iter::SkipSamplesDecoderIter;
+pub use take_samples_decoder_iter::TakeSamplesDecoderIter;
 
 #[cfg(all(feature = "enable-filesystem", feature = "enable-ffmpeg"))]
 pub mod ffmpeg;

--- a/src/backend/decode/select_channels_decoder_iter.rs
+++ b/src/backend/decode/select_channels_decoder_iter.rs
@@ -1,0 +1,67 @@
+use crate::backend::decode::decoder_iter::DecoderIter;
+use crate::backend::signal::Signal;
+
+pub struct SelectChannelsDecoderIter<D: DecoderIter> {
+    iter: D,
+    original_num_channels: usize,
+    selected_num_channels: usize,
+    disabled: bool,
+    channel_idx: usize,
+}
+
+impl<D: DecoderIter> SelectChannelsDecoderIter<D> {
+    #[inline]
+    pub fn new(iter: D, selected_num_channels: u16) -> Self {
+        let original_num_channels: usize = iter.num_channels() as usize;
+        let selected_num_channels: usize =
+            std::cmp::min(selected_num_channels as usize, original_num_channels);
+        let disabled: bool =
+            selected_num_channels == 0 || selected_num_channels == original_num_channels;
+        Self {
+            iter,
+            original_num_channels,
+            selected_num_channels,
+            disabled,
+            channel_idx: 0,
+        }
+    }
+}
+
+impl<D: DecoderIter> DecoderIter for SelectChannelsDecoderIter<D> {}
+
+impl<D: DecoderIter> Signal for SelectChannelsDecoderIter<D> {
+    #[inline(always)]
+    fn frame_rate_hz(&self) -> u32 {
+        self.iter.frame_rate_hz()
+    }
+
+    #[inline(always)]
+    fn num_channels(&self) -> u16 {
+        self.selected_num_channels as u16
+    }
+
+    #[inline(always)]
+    fn num_frames_estimate(&self) -> Option<usize> {
+        self.iter.num_frames_estimate()
+    }
+}
+
+impl<D: DecoderIter> Iterator for SelectChannelsDecoderIter<D> {
+    type Item = f32;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.disabled {
+            return self.iter.next();
+        }
+        loop {
+            let iter_next = self.iter.next();
+            let channel_idx = self.channel_idx;
+            self.channel_idx = (self.channel_idx + 1) % self.original_num_channels;
+            if channel_idx >= self.selected_num_channels {
+                continue;
+            }
+            return iter_next;
+        }
+    }
+}

--- a/src/backend/decode/skip_samples_decoder_iter.rs
+++ b/src/backend/decode/skip_samples_decoder_iter.rs
@@ -1,0 +1,60 @@
+use crate::backend::decode::decoder_iter::DecoderIter;
+use crate::backend::signal::Signal;
+
+pub struct SkipSamplesDecoderIter<D: DecoderIter> {
+    iter: D,
+    count: usize,
+    disabled: bool,
+}
+
+impl<D: DecoderIter> SkipSamplesDecoderIter<D> {
+    #[inline(always)]
+    pub fn new(iter: D, count: usize) -> Self {
+        let disabled: bool = count == 0;
+        Self {
+            iter,
+            count,
+            disabled,
+        }
+    }
+}
+
+impl<D: DecoderIter> DecoderIter for SkipSamplesDecoderIter<D> {}
+
+impl<D: DecoderIter> Signal for SkipSamplesDecoderIter<D> {
+    #[inline(always)]
+    fn frame_rate_hz(&self) -> u32 {
+        self.iter.frame_rate_hz()
+    }
+
+    #[inline(always)]
+    fn num_channels(&self) -> u16 {
+        self.iter.num_channels()
+    }
+
+    #[inline(always)]
+    fn num_frames_estimate(&self) -> Option<usize> {
+        self.iter.num_frames_estimate()
+    }
+}
+
+impl<D: DecoderIter> Iterator for SkipSamplesDecoderIter<D> {
+    type Item = f32;
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.disabled {
+            return self.iter.next();
+        }
+        while self.count > 0 {
+            self.iter.next();
+            self.count -= 1;
+        }
+        self.iter.next()
+    }
+}

--- a/src/backend/decode/symphonia/decoder_iter.rs
+++ b/src/backend/decode/symphonia/decoder_iter.rs
@@ -13,6 +13,7 @@ pub struct SymphoniaDecoderIter<'a> {
     frame_rate_hz: u32,
     num_channels: u16,
     est_num_frames: Option<usize>,
+    sample_idx: usize,
     current_packet_audio_buffer: Option<SampleBuffer<f32>>,
     current_packet_sample_idx: usize,
     error: Result<(), Error>,
@@ -50,6 +51,7 @@ impl<'a> SymphoniaDecoderIter<'a> {
             frame_rate_hz,
             num_channels,
             est_num_frames,
+            sample_idx: 0,
             current_packet_audio_buffer: None,
             current_packet_sample_idx: 0,
             error: Ok(()),
@@ -100,12 +102,35 @@ impl<'a> Signal for SymphoniaDecoderIter<'a> {
 
     #[inline(always)]
     fn num_frames_estimate(&self) -> Option<usize> {
-        self.est_num_frames
+        match self.est_num_frames {
+            None => None,
+            Some(est_num_frames) => {
+                let current_frame_idx = self.sample_idx / self.num_channels as usize;
+                if current_frame_idx >= est_num_frames {
+                    return None;
+                }
+                Some(est_num_frames - current_frame_idx)
+            }
+        }
     }
 }
 
 impl<'a> Iterator for SymphoniaDecoderIter<'a> {
     type Item = f32;
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.est_num_frames {
+            None => (0, None),
+            Some(est_num_frames) => {
+                let est_num_samples = est_num_frames * self.num_channels as usize;
+                if self.sample_idx >= est_num_samples {
+                    return (0, None);
+                }
+                (est_num_samples - self.sample_idx, None)
+            }
+        }
+    }
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -117,8 +142,60 @@ impl<'a> Iterator for SymphoniaDecoderIter<'a> {
                 continue;
             }
             let next_sample = buffer.samples()[self.current_packet_sample_idx];
+            self.sample_idx += 1;
             self.current_packet_sample_idx += 1;
             return Some(next_sample);
         }
+    }
+}
+
+#[cfg(all(test, feature = "enable-ffmpeg"))]
+mod test_symphonia_decoder_iter {
+    use crate::decode::SymphoniaDecoder;
+
+    pub const COF_FILENAME: &str = "./audio-for-tests/circus-of-freaks/track.flac";
+    pub const COF_NUM_CHANNELS: u16 = 2;
+    pub const COF_NUM_FRAMES: usize = 2491247;
+    pub const COF_NUM_SAMPLES: usize = COF_NUM_FRAMES * COF_NUM_CHANNELS as usize;
+
+    pub const MONO_DTMF_FILENAME: &str = "./audio-for-tests/mono-dtmf-tones/track.flac";
+    pub const MONO_DTMF_NUM_CHANNELS: u16 = 1;
+    pub const MONO_DTMF_NUM_FRAMES: usize = 441000;
+    pub const MONO_DTMF_SAMPLES: usize = MONO_DTMF_NUM_FRAMES * MONO_DTMF_NUM_CHANNELS as usize;
+
+    #[test]
+    fn test_cof_size_hint_1() {
+        let mut decoder =
+            SymphoniaDecoder::from_file(COF_FILENAME).expect("Failed to decode circus-of-freaks");
+        let mut decoder_iter = decoder.begin().expect("Failed to create DecoderIter");
+        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES, None));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES - 1, None));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES - 2, None));
+        let decoder_iter = decoder_iter.skip(10);
+        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES - 12, None));
+        let mut decoder_iter = decoder_iter.take(1000);
+        assert_eq!(decoder_iter.size_hint(), (1000, Some(1000)));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (999, Some(999)));
+    }
+
+    #[test]
+    fn test_mono_dtmf_size_hint_1() {
+        let mut decoder = SymphoniaDecoder::from_file(MONO_DTMF_FILENAME)
+            .expect("Failed to decode mono-dtmf-tones");
+        let mut decoder_iter = decoder.begin().expect("Failed to create DecoderIter");
+        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES, None));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES - 1, None));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES - 2, None));
+        let decoder_iter = decoder_iter.skip(10);
+        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES - 12, None));
+        let mut decoder_iter = decoder_iter.take(1000);
+        assert_eq!(decoder_iter.size_hint(), (1000, Some(1000)));
+        decoder_iter.next();
+        assert_eq!(decoder_iter.size_hint(), (999, Some(999)));
     }
 }

--- a/src/backend/decode/take_samples_decoder_iter.rs
+++ b/src/backend/decode/take_samples_decoder_iter.rs
@@ -1,0 +1,60 @@
+use crate::backend::decode::decoder_iter::DecoderIter;
+use crate::backend::signal::Signal;
+
+pub struct TakeSamplesDecoderIter<D: DecoderIter> {
+    iter: D,
+    count: usize,
+    disabled: bool,
+}
+
+impl<D: DecoderIter> TakeSamplesDecoderIter<D> {
+    #[inline(always)]
+    pub fn new(iter: D, count: usize) -> Self {
+        let disabled: bool = count == 0;
+        Self {
+            iter,
+            count,
+            disabled,
+        }
+    }
+}
+
+impl<D: DecoderIter> DecoderIter for TakeSamplesDecoderIter<D> {}
+
+impl<D: DecoderIter> Signal for TakeSamplesDecoderIter<D> {
+    #[inline(always)]
+    fn frame_rate_hz(&self) -> u32 {
+        self.iter.frame_rate_hz()
+    }
+
+    #[inline(always)]
+    fn num_channels(&self) -> u16 {
+        self.iter.num_channels()
+    }
+
+    #[inline(always)]
+    fn num_frames_estimate(&self) -> Option<usize> {
+        self.iter.num_frames_estimate()
+    }
+}
+
+impl<D: DecoderIter> Iterator for TakeSamplesDecoderIter<D> {
+    type Item = f32;
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.disabled {
+            return self.iter.next();
+        }
+        if self.count == 0 {
+            return None;
+        }
+        self.count -= 1;
+        self.iter.next()
+    }
+}


### PR DESCRIPTION
Instead of using bare loops, we now have a library of Rust iterators that can add bounds to our Decoders.