### PR TITLE
Rename `DecodeIter` to `Source`

### DIFF
--- a/src/backend/decoder.rs
+++ b/src/backend/decoder.rs
@@ -10,16 +10,16 @@ use std::marker::Sync;
 use crate::backend::constants::*;
 use crate::backend::errors::Error;
 use crate::backend::signal::Signal;
-use crate::backend::DecoderIter;
+use crate::backend::Source;
 
 /// Methods common to all audio decoders.
 pub trait Decoder: Signal {
-    fn begin(&mut self) -> Result<Box<dyn DecoderIter + '_>, Error>;
+    fn begin(&mut self) -> Result<Box<dyn Source + '_>, Error>;
 }
 
 impl Decoder for Box<dyn Decoder> {
     #[inline(always)]
-    fn begin(&mut self) -> Result<Box<dyn DecoderIter + '_>, Error> {
+    fn begin(&mut self) -> Result<Box<dyn Source + '_>, Error> {
         (&mut **self).begin()
     }
 }

--- a/src/backend/ffmpeg/decoder.rs
+++ b/src/backend/ffmpeg/decoder.rs
@@ -12,10 +12,10 @@ use ffmpeg_next::Stream;
 
 use crate::backend::errors::Error;
 use crate::backend::ffmpeg::ffmpeg_init;
-use crate::backend::ffmpeg::FFmpegDecoderIter;
+use crate::backend::ffmpeg::FFmpegSource;
 use crate::backend::signal::Signal;
 use crate::backend::Decoder;
-use crate::backend::DecoderIter;
+use crate::backend::Source;
 
 #[inline(always)]
 fn new_input_for_file<F: Clone + AsRef<Path>>(filename: F) -> Result<Input, Error> {
@@ -127,10 +127,10 @@ impl FFmpegDecoder {
 
 impl Decoder for FFmpegDecoder {
     #[inline(always)]
-    fn begin(&mut self) -> Result<Box<dyn DecoderIter + '_>, Error> {
+    fn begin(&mut self) -> Result<Box<dyn Source + '_>, Error> {
         let format = self.decoder.format();
         match format {
-            FFmpegSample::I16(Packed) => Ok(Box::new(FFmpegDecoderIter::<i16, true>::new(
+            FFmpegSample::I16(Packed) => Ok(Box::new(FFmpegSource::<i16, true>::new(
                 &mut self.input,
                 &mut self.decoder,
                 self.stream_index,
@@ -138,7 +138,7 @@ impl Decoder for FFmpegDecoder {
                 self.num_channels,
                 self.est_num_frames,
             ))),
-            FFmpegSample::I16(Planar) => Ok(Box::new(FFmpegDecoderIter::<i16, false>::new(
+            FFmpegSample::I16(Planar) => Ok(Box::new(FFmpegSource::<i16, false>::new(
                 &mut self.input,
                 &mut self.decoder,
                 self.stream_index,
@@ -146,7 +146,7 @@ impl Decoder for FFmpegDecoder {
                 self.num_channels,
                 self.est_num_frames,
             ))),
-            FFmpegSample::I32(Packed) => Ok(Box::new(FFmpegDecoderIter::<i32, true>::new(
+            FFmpegSample::I32(Packed) => Ok(Box::new(FFmpegSource::<i32, true>::new(
                 &mut self.input,
                 &mut self.decoder,
                 self.stream_index,
@@ -154,7 +154,7 @@ impl Decoder for FFmpegDecoder {
                 self.num_channels,
                 self.est_num_frames,
             ))),
-            FFmpegSample::I32(Planar) => Ok(Box::new(FFmpegDecoderIter::<i32, false>::new(
+            FFmpegSample::I32(Planar) => Ok(Box::new(FFmpegSource::<i32, false>::new(
                 &mut self.input,
                 &mut self.decoder,
                 self.stream_index,
@@ -162,7 +162,7 @@ impl Decoder for FFmpegDecoder {
                 self.num_channels,
                 self.est_num_frames,
             ))),
-            FFmpegSample::F32(Packed) => Ok(Box::new(FFmpegDecoderIter::<f32, true>::new(
+            FFmpegSample::F32(Packed) => Ok(Box::new(FFmpegSource::<f32, true>::new(
                 &mut self.input,
                 &mut self.decoder,
                 self.stream_index,
@@ -170,7 +170,7 @@ impl Decoder for FFmpegDecoder {
                 self.num_channels,
                 self.est_num_frames,
             ))),
-            FFmpegSample::F32(Planar) => Ok(Box::new(FFmpegDecoderIter::<f32, false>::new(
+            FFmpegSample::F32(Planar) => Ok(Box::new(FFmpegSource::<f32, false>::new(
                 &mut self.input,
                 &mut self.decoder,
                 self.stream_index,
@@ -178,7 +178,7 @@ impl Decoder for FFmpegDecoder {
                 self.num_channels,
                 self.est_num_frames,
             ))),
-            FFmpegSample::F64(Packed) => Ok(Box::new(FFmpegDecoderIter::<f64, true>::new(
+            FFmpegSample::F64(Packed) => Ok(Box::new(FFmpegSource::<f64, true>::new(
                 &mut self.input,
                 &mut self.decoder,
                 self.stream_index,
@@ -186,7 +186,7 @@ impl Decoder for FFmpegDecoder {
                 self.num_channels,
                 self.est_num_frames,
             ))),
-            FFmpegSample::F64(Planar) => Ok(Box::new(FFmpegDecoderIter::<f64, false>::new(
+            FFmpegSample::F64(Planar) => Ok(Box::new(FFmpegSource::<f64, false>::new(
                 &mut self.input,
                 &mut self.decoder,
                 self.stream_index,

--- a/src/backend/ffmpeg/mod.rs
+++ b/src/backend/ffmpeg/mod.rs
@@ -1,7 +1,7 @@
 mod decoder;
-mod decoder_iter;
 mod init;
+mod source;
 
 pub use decoder::FFmpegDecoder;
-pub use decoder_iter::FFmpegDecoderIter;
 pub use init::ffmpeg_init;
+pub use source::FFmpegSource;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -17,10 +17,10 @@ pub mod symphonia;
 
 mod batch_args;
 mod common;
-mod decoder_iter;
 mod errors;
 mod sample;
 mod signal;
+mod source;
 mod waveform;
 mod waveform_args;
 mod waveform_named_result;
@@ -28,10 +28,10 @@ mod waveform_result;
 
 pub use batch_args::BatchArgs;
 pub use decoder::Decoder;
-pub use decoder_iter::DecoderIter;
 pub use errors::Error;
 pub use sample::Sample;
 pub use signal::Signal;
+pub use source::Source;
 pub use waveform::Waveform;
 pub use waveform_args::WaveformArgs;
 pub use waveform_named_result::WaveformNamedResult;

--- a/src/backend/source/convert_to_mono.rs
+++ b/src/backend/source/convert_to_mono.rs
@@ -1,16 +1,16 @@
 use crate::backend::signal::Signal;
-use crate::backend::DecoderIter;
+use crate::backend::Source;
 
-pub struct ConvertToMono<D: DecoderIter> {
-    iter: D,
+pub struct ConvertToMono<S: Source> {
+    iter: S,
     disabled: bool,
     iter_num_channels_usize: usize,
     iter_num_channels_f32: f32,
 }
 
-impl<D: DecoderIter> ConvertToMono<D> {
+impl<S: Source> ConvertToMono<S> {
     #[inline(always)]
-    pub fn new(iter: D, enabled: bool) -> Self {
+    pub fn new(iter: S, enabled: bool) -> Self {
         let iter_num_channels_usize: usize = iter.num_channels() as usize;
         let iter_num_channels_f32: f32 = iter_num_channels_usize as f32;
         Self {
@@ -22,9 +22,9 @@ impl<D: DecoderIter> ConvertToMono<D> {
     }
 }
 
-impl<D: DecoderIter> DecoderIter for ConvertToMono<D> {}
+impl<S: Source> Source for ConvertToMono<S> {}
 
-impl<D: DecoderIter> Signal for ConvertToMono<D> {
+impl<S: Source> Signal for ConvertToMono<S> {
     #[inline(always)]
     fn frame_rate_hz(&self) -> u32 {
         self.iter.frame_rate_hz()
@@ -41,7 +41,7 @@ impl<D: DecoderIter> Signal for ConvertToMono<D> {
     }
 }
 
-impl<D: DecoderIter> Iterator for ConvertToMono<D> {
+impl<S: Source> Iterator for ConvertToMono<S> {
     type Item = f32;
 
     #[inline(always)]

--- a/src/backend/source/mod.rs
+++ b/src/backend/source/mod.rs
@@ -11,7 +11,7 @@ pub use take_samples::TakeSamples;
 use crate::backend::signal::Signal;
 
 /// A sample iterator created by an audio decoder.
-pub trait DecoderIter: Signal + Iterator<Item = f32> {
+pub trait Source: Signal + Iterator<Item = f32> {
     #[inline(always)]
     fn skip_samples(self, count: usize) -> SkipSamples<Self>
     where
@@ -45,9 +45,9 @@ pub trait DecoderIter: Signal + Iterator<Item = f32> {
     }
 }
 
-impl DecoderIter for Box<dyn DecoderIter + '_> {}
+impl Source for Box<dyn Source + '_> {}
 
-impl Signal for Box<dyn DecoderIter + '_> {
+impl Signal for Box<dyn Source + '_> {
     #[inline(always)]
     fn frame_rate_hz(&self) -> u32 {
         (&**self).frame_rate_hz()

--- a/src/backend/source/select_channels.rs
+++ b/src/backend/source/select_channels.rs
@@ -1,17 +1,17 @@
 use crate::backend::signal::Signal;
-use crate::backend::DecoderIter;
+use crate::backend::Source;
 
-pub struct SelectChannels<D: DecoderIter> {
-    iter: D,
+pub struct SelectChannels<S: Source> {
+    iter: S,
     original_num_channels: usize,
     selected_num_channels: usize,
     disabled: bool,
     channel_idx: usize,
 }
 
-impl<D: DecoderIter> SelectChannels<D> {
+impl<S: Source> SelectChannels<S> {
     #[inline]
-    pub fn new(iter: D, selected_num_channels: u16) -> Self {
+    pub fn new(iter: S, selected_num_channels: u16) -> Self {
         let original_num_channels: usize = iter.num_channels() as usize;
         let selected_num_channels: usize =
             std::cmp::min(selected_num_channels as usize, original_num_channels);
@@ -27,9 +27,9 @@ impl<D: DecoderIter> SelectChannels<D> {
     }
 }
 
-impl<D: DecoderIter> DecoderIter for SelectChannels<D> {}
+impl<S: Source> Source for SelectChannels<S> {}
 
-impl<D: DecoderIter> Signal for SelectChannels<D> {
+impl<S: Source> Signal for SelectChannels<S> {
     #[inline(always)]
     fn frame_rate_hz(&self) -> u32 {
         self.iter.frame_rate_hz()
@@ -46,7 +46,7 @@ impl<D: DecoderIter> Signal for SelectChannels<D> {
     }
 }
 
-impl<D: DecoderIter> Iterator for SelectChannels<D> {
+impl<S: Source> Iterator for SelectChannels<S> {
     type Item = f32;
 
     #[inline]

--- a/src/backend/source/skip_samples.rs
+++ b/src/backend/source/skip_samples.rs
@@ -1,15 +1,15 @@
 use crate::backend::signal::Signal;
-use crate::backend::DecoderIter;
+use crate::backend::Source;
 
-pub struct TakeSamples<D: DecoderIter> {
-    iter: D,
+pub struct SkipSamples<S: Source> {
+    iter: S,
     count: usize,
     disabled: bool,
 }
 
-impl<D: DecoderIter> TakeSamples<D> {
+impl<S: Source> SkipSamples<S> {
     #[inline(always)]
-    pub fn new(iter: D, count: usize) -> Self {
+    pub fn new(iter: S, count: usize) -> Self {
         let disabled: bool = count == 0;
         Self {
             iter,
@@ -19,9 +19,9 @@ impl<D: DecoderIter> TakeSamples<D> {
     }
 }
 
-impl<D: DecoderIter> DecoderIter for TakeSamples<D> {}
+impl<S: Source> Source for SkipSamples<S> {}
 
-impl<D: DecoderIter> Signal for TakeSamples<D> {
+impl<S: Source> Signal for SkipSamples<S> {
     #[inline(always)]
     fn frame_rate_hz(&self) -> u32 {
         self.iter.frame_rate_hz()
@@ -38,7 +38,7 @@ impl<D: DecoderIter> Signal for TakeSamples<D> {
     }
 }
 
-impl<D: DecoderIter> Iterator for TakeSamples<D> {
+impl<S: Source> Iterator for SkipSamples<S> {
     type Item = f32;
 
     #[inline(always)]
@@ -51,10 +51,10 @@ impl<D: DecoderIter> Iterator for TakeSamples<D> {
         if self.disabled {
             return self.iter.next();
         }
-        if self.count == 0 {
-            return None;
+        while self.count > 0 {
+            self.iter.next();
+            self.count -= 1;
         }
-        self.count -= 1;
         self.iter.next()
     }
 }

--- a/src/backend/source/take_samples.rs
+++ b/src/backend/source/take_samples.rs
@@ -1,15 +1,15 @@
 use crate::backend::signal::Signal;
-use crate::backend::DecoderIter;
+use crate::backend::Source;
 
-pub struct SkipSamples<D: DecoderIter> {
-    iter: D,
+pub struct TakeSamples<S: Source> {
+    iter: S,
     count: usize,
     disabled: bool,
 }
 
-impl<D: DecoderIter> SkipSamples<D> {
+impl<S: Source> TakeSamples<S> {
     #[inline(always)]
-    pub fn new(iter: D, count: usize) -> Self {
+    pub fn new(iter: S, count: usize) -> Self {
         let disabled: bool = count == 0;
         Self {
             iter,
@@ -19,9 +19,9 @@ impl<D: DecoderIter> SkipSamples<D> {
     }
 }
 
-impl<D: DecoderIter> DecoderIter for SkipSamples<D> {}
+impl<S: Source> Source for TakeSamples<S> {}
 
-impl<D: DecoderIter> Signal for SkipSamples<D> {
+impl<S: Source> Signal for TakeSamples<S> {
     #[inline(always)]
     fn frame_rate_hz(&self) -> u32 {
         self.iter.frame_rate_hz()
@@ -38,7 +38,7 @@ impl<D: DecoderIter> Signal for SkipSamples<D> {
     }
 }
 
-impl<D: DecoderIter> Iterator for SkipSamples<D> {
+impl<S: Source> Iterator for TakeSamples<S> {
     type Item = f32;
 
     #[inline(always)]
@@ -51,10 +51,10 @@ impl<D: DecoderIter> Iterator for SkipSamples<D> {
         if self.disabled {
             return self.iter.next();
         }
-        while self.count > 0 {
-            self.iter.next();
-            self.count -= 1;
+        if self.count == 0 {
+            return None;
         }
+        self.count -= 1;
         self.iter.next()
     }
 }

--- a/src/backend/symphonia/decoder.rs
+++ b/src/backend/symphonia/decoder.rs
@@ -18,9 +18,9 @@ use crate::backend::constants::DEFAULT_MIME_TYPE;
 use crate::backend::errors::Error;
 use crate::backend::signal::Signal;
 use crate::backend::Decoder;
-use crate::backend::DecoderIter;
+use crate::backend::Source;
 
-use crate::backend::symphonia::SymphoniaDecoderIter;
+use crate::backend::symphonia::SymphoniaSource;
 
 /// An audio decoder from Philip Deljanov's [`symphonia`] audio decoding library.
 pub struct SymphoniaDecoder {
@@ -140,8 +140,8 @@ impl SymphoniaDecoder {
 
 impl Decoder for SymphoniaDecoder {
     #[inline(always)]
-    fn begin(&mut self) -> Result<Box<dyn DecoderIter + '_>, Error> {
-        let decode_iter = SymphoniaDecoderIter::new(
+    fn begin(&mut self) -> Result<Box<dyn Source + '_>, Error> {
+        let decode_iter = SymphoniaSource::new(
             &mut self.reader,
             self.frame_rate_hz,
             self.num_channels,

--- a/src/backend/symphonia/mod.rs
+++ b/src/backend/symphonia/mod.rs
@@ -1,5 +1,5 @@
 mod decoder;
-mod decoder_iter;
+mod source;
 
 pub use decoder::SymphoniaDecoder;
-pub use decoder_iter::SymphoniaDecoderIter;
+pub use source::SymphoniaSource;

--- a/src/backend/symphonia/source.rs
+++ b/src/backend/symphonia/source.rs
@@ -5,9 +5,9 @@ use symphonia::core::formats::{FormatReader, Track};
 
 use crate::backend::errors::Error;
 use crate::backend::signal::Signal;
-use crate::backend::DecoderIter;
+use crate::backend::Source;
 
-pub struct SymphoniaDecoderIter<'a> {
+pub struct SymphoniaSource<'a> {
     decoder: Box<dyn SymphoniaDecoderTrait>,
     reader: &'a mut Box<dyn FormatReader>,
     frame_rate_hz: u32,
@@ -19,7 +19,7 @@ pub struct SymphoniaDecoderIter<'a> {
     error: Result<(), Error>,
 }
 
-impl<'a> SymphoniaDecoderIter<'a> {
+impl<'a> SymphoniaSource<'a> {
     pub fn new(
         reader: &'a mut Box<dyn FormatReader>,
         frame_rate_hz: u32,
@@ -87,9 +87,9 @@ impl<'a> SymphoniaDecoderIter<'a> {
     }
 }
 
-impl<'a> DecoderIter for SymphoniaDecoderIter<'a> {}
+impl<'a> Source for SymphoniaSource<'a> {}
 
-impl<'a> Signal for SymphoniaDecoderIter<'a> {
+impl<'a> Signal for SymphoniaSource<'a> {
     #[inline(always)]
     fn frame_rate_hz(&self) -> u32 {
         self.frame_rate_hz
@@ -115,7 +115,7 @@ impl<'a> Signal for SymphoniaDecoderIter<'a> {
     }
 }
 
-impl<'a> Iterator for SymphoniaDecoderIter<'a> {
+impl<'a> Iterator for SymphoniaSource<'a> {
     type Item = f32;
 
     #[inline(always)]
@@ -150,7 +150,7 @@ impl<'a> Iterator for SymphoniaDecoderIter<'a> {
 }
 
 #[cfg(all(test, feature = "enable-ffmpeg"))]
-mod test_symphonia_decoder_iter {
+mod test_symphonia_source {
     use crate::backend::symphonia::SymphoniaDecoder;
 
     pub const COF_FILENAME: &str = "./audio-for-tests/circus-of-freaks/track.flac";
@@ -167,35 +167,35 @@ mod test_symphonia_decoder_iter {
     fn test_cof_size_hint_1() {
         let mut decoder =
             SymphoniaDecoder::from_file(COF_FILENAME).expect("Failed to decode circus-of-freaks");
-        let mut decoder_iter = decoder.begin().expect("Failed to create DecoderIter");
-        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES, None));
-        decoder_iter.next();
-        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES - 1, None));
-        decoder_iter.next();
-        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES - 2, None));
-        let decoder_iter = decoder_iter.skip(10);
-        assert_eq!(decoder_iter.size_hint(), (COF_NUM_SAMPLES - 12, None));
-        let mut decoder_iter = decoder_iter.take(1000);
-        assert_eq!(decoder_iter.size_hint(), (1000, Some(1000)));
-        decoder_iter.next();
-        assert_eq!(decoder_iter.size_hint(), (999, Some(999)));
+        let mut source = decoder.begin().expect("Failed to create Source");
+        assert_eq!(source.size_hint(), (COF_NUM_SAMPLES, None));
+        source.next();
+        assert_eq!(source.size_hint(), (COF_NUM_SAMPLES - 1, None));
+        source.next();
+        assert_eq!(source.size_hint(), (COF_NUM_SAMPLES - 2, None));
+        let source = source.skip(10);
+        assert_eq!(source.size_hint(), (COF_NUM_SAMPLES - 12, None));
+        let mut source = source.take(1000);
+        assert_eq!(source.size_hint(), (1000, Some(1000)));
+        source.next();
+        assert_eq!(source.size_hint(), (999, Some(999)));
     }
 
     #[test]
     fn test_mono_dtmf_size_hint_1() {
         let mut decoder = SymphoniaDecoder::from_file(MONO_DTMF_FILENAME)
             .expect("Failed to decode mono-dtmf-tones");
-        let mut decoder_iter = decoder.begin().expect("Failed to create DecoderIter");
-        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES, None));
-        decoder_iter.next();
-        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES - 1, None));
-        decoder_iter.next();
-        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES - 2, None));
-        let decoder_iter = decoder_iter.skip(10);
-        assert_eq!(decoder_iter.size_hint(), (MONO_DTMF_SAMPLES - 12, None));
-        let mut decoder_iter = decoder_iter.take(1000);
-        assert_eq!(decoder_iter.size_hint(), (1000, Some(1000)));
-        decoder_iter.next();
-        assert_eq!(decoder_iter.size_hint(), (999, Some(999)));
+        let mut source = decoder.begin().expect("Failed to create Source");
+        assert_eq!(source.size_hint(), (MONO_DTMF_SAMPLES, None));
+        source.next();
+        assert_eq!(source.size_hint(), (MONO_DTMF_SAMPLES - 1, None));
+        source.next();
+        assert_eq!(source.size_hint(), (MONO_DTMF_SAMPLES - 2, None));
+        let source = source.skip(10);
+        assert_eq!(source.size_hint(), (MONO_DTMF_SAMPLES - 12, None));
+        let mut source = source.take(1000);
+        assert_eq!(source.size_hint(), (1000, Some(1000)));
+        source.next();
+        assert_eq!(source.size_hint(), (999, Some(999)));
     }
 }

--- a/src/backend/waveform.rs
+++ b/src/backend/waveform.rs
@@ -15,7 +15,7 @@ use crate::backend::errors::Error;
 use crate::backend::resample::resample;
 use crate::backend::signal::Signal;
 use crate::backend::Decoder;
-use crate::backend::DecoderIter;
+use crate::backend::Source;
 use crate::backend::WaveformArgs;
 
 #[cfg(feature = "enable-filesystem")]
@@ -137,13 +137,13 @@ impl Waveform {
         };
         let mut interleaved_samples: Vec<f32> = Vec::with_capacity(interleaved_samples_capacity);
 
-        let decoder_iter = decoder.begin()?;
-        let bounded_decoder_iter = decoder_iter
+        let source = decoder.begin()?;
+        let bounded_source = source
             .skip_samples(start_sample_idx)
             .take_samples(take_samples)
             .select_first_channels(selected_num_channels)
             .convert_to_mono(args.convert_to_mono);
-        for sample in bounded_decoder_iter {
+        for sample in bounded_source {
             interleaved_samples.push(sample);
         }
 


### PR DESCRIPTION
The word `Source` is a more generic name for
what an iterator on a decoder is doing.