### PR TITLE
Use dynamic dispatch for decoding iterators

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -13,6 +13,7 @@ pub mod resample;
 pub mod build_info;
 pub mod constants;
 pub mod decoder;
+pub mod source;
 pub mod symphonia;
 
 mod batch_args;
@@ -20,7 +21,6 @@ mod common;
 mod errors;
 mod sample;
 mod signal;
-mod source;
 mod waveform;
 mod waveform_args;
 mod waveform_named_result;

--- a/src/backend/source/mod.rs
+++ b/src/backend/source/mod.rs
@@ -2,11 +2,13 @@ mod convert_to_mono;
 mod select_channels;
 mod skip_samples;
 mod take_samples;
+mod waveform_source;
 
 pub use convert_to_mono::ConvertToMono;
 pub use select_channels::SelectChannels;
 pub use skip_samples::SkipSamples;
 pub use take_samples::TakeSamples;
+pub use waveform_source::WaveformSource;
 
 use crate::backend::signal::Signal;
 
@@ -37,11 +39,11 @@ pub trait Source: Signal + Iterator<Item = f32> {
     }
 
     #[inline(always)]
-    fn convert_to_mono(self, enabled: bool) -> ConvertToMono<Self>
+    fn convert_to_mono(self) -> ConvertToMono<Self>
     where
         Self: Sized,
     {
-        ConvertToMono::new(self, enabled)
+        ConvertToMono::new(self)
     }
 }
 

--- a/src/backend/source/take_samples.rs
+++ b/src/backend/source/take_samples.rs
@@ -4,18 +4,12 @@ use crate::backend::Source;
 pub struct TakeSamples<S: Source> {
     iter: S,
     count: usize,
-    disabled: bool,
 }
 
 impl<S: Source> TakeSamples<S> {
     #[inline(always)]
     pub fn new(iter: S, count: usize) -> Self {
-        let disabled: bool = count == 0;
-        Self {
-            iter,
-            count,
-            disabled,
-        }
+        Self { iter, count }
     }
 }
 
@@ -43,18 +37,68 @@ impl<S: Source> Iterator for TakeSamples<S> {
 
     #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+        if self.count == 0 {
+            return (0, Some(0));
+        }
+        let (lower, upper) = self.iter.size_hint();
+        let lower = std::cmp::min(lower, self.count);
+        let upper = match upper {
+            Some(x) if x < self.count => Some(x),
+            _ => Some(self.count),
+        };
+        (lower, upper)
     }
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.disabled {
-            return self.iter.next();
-        }
         if self.count == 0 {
             return None;
         }
         self.count -= 1;
         self.iter.next()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backend::{Source, Waveform};
+
+    #[test]
+    fn test_size_hint_1() {
+        let frame_rate_hz: u32 = 1234;
+        let num_channels: u16 = 3;
+        let waveform = Waveform::new(
+            frame_rate_hz,
+            num_channels,
+            vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        );
+
+        let ws = waveform.to_source();
+        assert_eq!(ws.size_hint().0, 6);
+        assert_eq!(ws.size_hint().1.unwrap(), 6);
+
+        let mut ws = ws.take_samples(5);
+        assert_eq!(ws.size_hint().0, 5);
+        assert_eq!(ws.size_hint().1.unwrap(), 5);
+
+        ws.next();
+        assert_eq!(ws.size_hint().0, 4);
+        assert_eq!(ws.size_hint().1.unwrap(), 4);
+
+        let ws = ws.take_samples(5);
+        assert_eq!(ws.size_hint().0, 4);
+        assert_eq!(ws.size_hint().1.unwrap(), 4);
+
+        let ws = ws.take_samples(3);
+        assert_eq!(ws.size_hint().0, 3);
+        assert_eq!(ws.size_hint().1.unwrap(), 3);
+
+        let ws = ws.take_samples(3);
+        assert_eq!(ws.size_hint().0, 3);
+        assert_eq!(ws.size_hint().1.unwrap(), 3);
+
+        let ws = ws.take_samples(0);
+        assert_eq!(ws.size_hint().0, 0);
+        assert_eq!(ws.size_hint().1.unwrap(), 0);
     }
 }

--- a/src/backend/source/waveform_source.rs
+++ b/src/backend/source/waveform_source.rs
@@ -1,0 +1,65 @@
+use crate::backend::{Signal, Source};
+
+pub struct WaveformSource<'a> {
+    interleaved_samples: &'a [f32],
+    frame_rate_hz: u32,
+    num_channels: u16,
+    current_sample: usize,
+}
+
+impl<'a> WaveformSource<'a> {
+    pub fn new(interleaved_samples: &'a [f32], frame_rate_hz: u32, num_channels: u16) -> Self {
+        Self {
+            interleaved_samples,
+            frame_rate_hz,
+            num_channels,
+            current_sample: 0,
+        }
+    }
+}
+
+impl<'a> Source for WaveformSource<'a> {}
+
+impl<'a> Signal for WaveformSource<'a> {
+    #[inline(always)]
+    fn frame_rate_hz(&self) -> u32 {
+        self.frame_rate_hz
+    }
+
+    #[inline(always)]
+    fn num_channels(&self) -> u16 {
+        self.num_channels
+    }
+
+    #[inline(always)]
+    fn num_frames_estimate(&self) -> Option<usize> {
+        let remaining_samples: usize = self.interleaved_samples.len() - self.current_sample;
+        Some(remaining_samples / self.num_channels as usize)
+    }
+}
+
+impl<'a> Iterator for WaveformSource<'a> {
+    type Item = f32;
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let diff = self.interleaved_samples.len() - self.current_sample;
+        (diff, Some(diff))
+    }
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_sample >= self.interleaved_samples.len() {
+            return None;
+        }
+        let retval: Option<Self::Item> = Some(self.interleaved_samples[self.current_sample]);
+        self.current_sample += 1;
+        retval
+    }
+
+    #[inline(always)]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.current_sample += n;
+        self.next()
+    }
+}

--- a/tests/test_waveform_source.rs
+++ b/tests/test_waveform_source.rs
@@ -1,0 +1,68 @@
+mod fixtures;
+
+mod test_waveform_source {
+    use crate::fixtures::*;
+
+    use babycat::source::WaveformSource;
+    use babycat::{Signal, Waveform};
+
+    pub const COF_NUM_SAMPLES: usize = COF_NUM_FRAMES * COF_NUM_CHANNELS as usize;
+
+    #[inline(always)]
+    #[track_caller]
+    fn assert_ws(ws: &WaveformSource, num_channels: u16, frame_rate_hz: u32, num_samples: usize) {
+        let num_frames = num_samples / num_channels as usize;
+        assert_eq!(num_channels, ws.num_channels(), "Wrong number of channels");
+        assert_eq!(frame_rate_hz, ws.frame_rate_hz(), "Wrong frame rate");
+        assert_eq!(
+            num_frames,
+            ws.num_frames_estimate().unwrap(),
+            "Wrong num_frames_estimate"
+        );
+        assert_eq!(num_samples, ws.size_hint().0, "Wrong size hint lower bound");
+        assert_eq!(
+            num_samples,
+            ws.size_hint().1.unwrap(),
+            "Wrong size hint upper bound"
+        );
+    }
+
+    #[test]
+    fn test_circus_of_freaks_default_1() {
+        let waveform = Waveform::from_file(COF_FILENAME, Default::default()).unwrap();
+        let mut ws = waveform.to_source();
+        assert_ws(&ws, COF_NUM_CHANNELS, COF_FRAME_RATE_HZ, COF_NUM_SAMPLES);
+        ws.next();
+        assert_ws(
+            &ws,
+            COF_NUM_CHANNELS,
+            COF_FRAME_RATE_HZ,
+            COF_NUM_SAMPLES - 1,
+        );
+        ws.next();
+        assert_ws(
+            &ws,
+            COF_NUM_CHANNELS,
+            COF_FRAME_RATE_HZ,
+            COF_NUM_SAMPLES - 2,
+        );
+        ws.nth(0);
+        assert_ws(
+            &ws,
+            COF_NUM_CHANNELS,
+            COF_FRAME_RATE_HZ,
+            COF_NUM_SAMPLES - 3,
+        );
+    }
+
+    #[test]
+    fn test_from_frames_of_silence() {
+        let frame_rate_hz: u32 = 1234;
+        let num_channels: u16 = 3;
+        let num_frames: usize = 101;
+        let num_samples: usize = num_frames * num_channels as usize;
+        let waveform = Waveform::from_frames_of_silence(frame_rate_hz, num_channels, num_frames);
+        let ws = waveform.to_source();
+        assert_ws(&ws, num_channels, frame_rate_hz, num_samples);
+    }
+}


### PR DESCRIPTION
Instead of having `enabled` / `disabled` flags in our `Source` iterators, we should just conditionally chain them using `Box`.