### PR TITLE
Fill out docs for the `build_info` functions

### DIFF
--- a/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_ffmpeg.rst
+++ b/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_ffmpeg.rst
@@ -1,0 +1,4 @@
+babycat_build_info_compiled_with_ffmpeg()
+=========================================
+
+.. doxygenfunction:: babycat_build_info_compiled_with_ffmpeg

--- a/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_ffmpeg_build_link_static.rst
+++ b/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_ffmpeg_build_link_static.rst
@@ -1,0 +1,4 @@
+babycat_build_info_compiled_with_ffmpeg_build_link_static()
+===========================================================
+
+.. doxygenfunction:: babycat_build_info_compiled_with_ffmpeg_build_link_static

--- a/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_ffmpeg_link_static.rst
+++ b/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_ffmpeg_link_static.rst
@@ -1,0 +1,4 @@
+babycat_build_info_compiled_with_ffmpeg_link_static()
+=====================================================
+
+.. doxygenfunction:: babycat_build_info_compiled_with_ffmpeg_link_static

--- a/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_filesystem.rst
+++ b/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_filesystem.rst
@@ -1,0 +1,4 @@
+babycat_build_info_compiled_with_filesystem()
+=============================================
+
+.. doxygenfunction:: babycat_build_info_compiled_with_filesystem

--- a/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_multithreading.rst
+++ b/docs/source/api/c/babycat_build_info/babycat_build_info_compiled_with_multithreading.rst
@@ -1,0 +1,4 @@
+babycat_build_info_compiled_with_multithreading()
+=================================================
+
+.. doxygenfunction:: babycat_build_info_compiled_with_multithreading

--- a/docs/source/api/c/babycat_build_info/babycat_build_info_copyright_license_spdx.rst
+++ b/docs/source/api/c/babycat_build_info/babycat_build_info_copyright_license_spdx.rst
@@ -1,0 +1,4 @@
+babycat_build_info_copyright_license_spdx()
+===========================================
+
+.. doxygenfunction:: babycat_build_info_copyright_license_spdx

--- a/docs/source/api/c/babycat_build_info/babycat_build_info_version.rst
+++ b/docs/source/api/c/babycat_build_info/babycat_build_info_version.rst
@@ -1,0 +1,4 @@
+babycat_build_info_version()
+============================
+
+.. doxygenfunction:: babycat_build_info_version

--- a/docs/source/api/c/babycat_build_info/index.rst
+++ b/docs/source/api/c/babycat_build_info/index.rst
@@ -1,0 +1,14 @@
+babycat_build_info
+==================
+
+.. toctree::
+   :maxdepth: 2
+
+   babycat_build_info_compiled_with_filesystem() <babycat_build_info_compiled_with_filesystem>
+   babycat_build_info_compiled_with_multithreading() <babycat_build_info_compiled_with_multithreading>
+   babycat_build_info_compiled_with_ffmpeg() <babycat_build_info_compiled_with_ffmpeg>
+   babycat_build_info_compiled_with_ffmpeg_link_static() <babycat_build_info_compiled_with_ffmpeg_link_static>
+   babycat_build_info_compiled_with_ffmpeg_build_link_static() <babycat_build_info_compiled_with_ffmpeg_build_link_static>
+   babycat_build_info_copyright_license_spdx() <babycat_build_info_copyright_license_spdx>
+   babycat_build_info_version() <babycat_build_info_version>
+

--- a/docs/source/api/c/index.rst
+++ b/docs/source/api/c/index.rst
@@ -5,6 +5,7 @@ Babycat C API Documentation
    :maxdepth: 1
    :hidden:
 
+   babycat_build_info/index
    babycat_WaveformArgs/index
    babycat_Waveform/index
    babycat_WaveformResult/index

--- a/docs/source/api/python/build_info/babycat_version.rst
+++ b/docs/source/api/python/build_info/babycat_version.rst
@@ -1,0 +1,4 @@
+babycat.build_info.babycat_version()
+====================================
+
+.. automethod:: babycat.build_info.babycat_version

--- a/docs/source/api/python/build_info/compiled_with_ffmpeg.rst
+++ b/docs/source/api/python/build_info/compiled_with_ffmpeg.rst
@@ -1,0 +1,4 @@
+babycat.build_info.compiled_with_ffmpeg()
+=========================================
+
+.. automethod:: babycat.build_info.compiled_with_ffmpeg

--- a/docs/source/api/python/build_info/compiled_with_ffmpeg_build_link_static.rst
+++ b/docs/source/api/python/build_info/compiled_with_ffmpeg_build_link_static.rst
@@ -1,0 +1,4 @@
+babycat.build_info.compiled_with_ffmpeg_build_link_static()
+===========================================================
+
+.. automethod:: babycat.build_info.compiled_with_ffmpeg_build_link_static

--- a/docs/source/api/python/build_info/compiled_with_ffmpeg_link_static.rst
+++ b/docs/source/api/python/build_info/compiled_with_ffmpeg_link_static.rst
@@ -1,0 +1,4 @@
+babycat.build_info.compiled_with_ffmpeg_link_static()
+=====================================================
+
+.. automethod:: babycat.build_info.compiled_with_ffmpeg_link_static

--- a/docs/source/api/python/build_info/compiled_with_filesystem.rst
+++ b/docs/source/api/python/build_info/compiled_with_filesystem.rst
@@ -1,0 +1,4 @@
+babycat.build_info.compiled_with_filesystem()
+=============================================
+
+.. automethod:: babycat.build_info.compiled_with_filesystem

--- a/docs/source/api/python/build_info/compiled_with_multithreading.rst
+++ b/docs/source/api/python/build_info/compiled_with_multithreading.rst
@@ -1,0 +1,4 @@
+babycat.build_info.compiled_with_multithreading()
+=================================================
+
+.. automethod:: babycat.build_info.compiled_with_multithreading

--- a/docs/source/api/python/build_info/copyright_license_spdx.rst
+++ b/docs/source/api/python/build_info/copyright_license_spdx.rst
@@ -1,0 +1,4 @@
+babycat.build_info.copyright_license_spdx()
+===========================================
+
+.. automethod:: babycat.build_info.copyright_license_spdx

--- a/docs/source/api/python/build_info/index.rst
+++ b/docs/source/api/python/build_info/index.rst
@@ -1,0 +1,16 @@
+babycat.build_info
+==================
+
+.. py:module:: babycat.build_info
+
+
+.. toctree::
+   :maxdepth: 2
+
+   .compiled_with_filesystem() <compiled_with_filesystem>
+   .compiled_with_multithreading() <compiled_with_multithreading>
+   .compiled_with_ffmpeg() <compiled_with_ffmpeg>
+   .compiled_with_ffmpeg_link_static() <compiled_with_ffmpeg_link_static>
+   .compiled_with_ffmpeg_build_link_static() <compiled_with_ffmpeg_build_link_static>
+   .copyright_license_spdx() <copyright_license_spdx>
+   .babycat_version() <babycat_version>

--- a/docs/source/api/python/index.rst
+++ b/docs/source/api/python/index.rst
@@ -5,6 +5,7 @@ Babycat Python API Documentation
    :maxdepth: 5
    :hidden:
 
+   build_info <build_info/index>
    batch <batch/index>
    Waveform <Waveform/index>
    WaveformNamedResult <WaveformNamedResult/index>

--- a/docs/source/api/wasm/BuildInfo/babycatVersion.rst
+++ b/docs/source/api/wasm/BuildInfo/babycatVersion.rst
@@ -1,0 +1,4 @@
+BuildInfo.babycatVersion()
+==========================
+
+.. js:autofunction:: babycatVersion

--- a/docs/source/api/wasm/BuildInfo/compiledWithFFmpeg.rst
+++ b/docs/source/api/wasm/BuildInfo/compiledWithFFmpeg.rst
@@ -1,0 +1,4 @@
+BuildInfo.compiledWithFFmpeg()
+==============================
+
+.. js:autofunction:: compiledWithFFmpeg

--- a/docs/source/api/wasm/BuildInfo/compiledWithFFmpegBuildLinkStatic.rst
+++ b/docs/source/api/wasm/BuildInfo/compiledWithFFmpegBuildLinkStatic.rst
@@ -1,0 +1,4 @@
+BuildInfo.compiledWithFFpegBuildLinkStatic()
+============================================
+
+.. js:autofunction:: compiledWithFFpegBuildLinkStatic

--- a/docs/source/api/wasm/BuildInfo/compiledWithFFmpegLinkStatic.rst
+++ b/docs/source/api/wasm/BuildInfo/compiledWithFFmpegLinkStatic.rst
@@ -1,0 +1,4 @@
+BuildInfo.compiledWithFFmpegLinkStatic()
+========================================
+
+.. js:autofunction:: compiledWithFFmpegLinkStatic

--- a/docs/source/api/wasm/BuildInfo/compiledWithFilesystem.rst
+++ b/docs/source/api/wasm/BuildInfo/compiledWithFilesystem.rst
@@ -1,0 +1,4 @@
+BuildInfo.compiledWithFilesystem()
+==================================
+
+.. js:autofunction:: compiledWithFilesystem

--- a/docs/source/api/wasm/BuildInfo/compiledWithMultithreading.rst
+++ b/docs/source/api/wasm/BuildInfo/compiledWithMultithreading.rst
@@ -1,0 +1,4 @@
+BuildInfo.compiledWithMultithreading()
+======================================
+
+.. js:autofunction:: compiledWithMultithreading

--- a/docs/source/api/wasm/BuildInfo/copyrightLicenseSPDX.rst
+++ b/docs/source/api/wasm/BuildInfo/copyrightLicenseSPDX.rst
@@ -1,0 +1,4 @@
+BuildInfo.copyrightLicenseSPDX()
+================================
+
+.. js:autofunction:: copyrightLicenseSPDX

--- a/docs/source/api/wasm/BuildInfo/index.rst
+++ b/docs/source/api/wasm/BuildInfo/index.rst
@@ -1,0 +1,14 @@
+babycat.BuildInfo
+=================
+
+.. toctree::
+   :maxdepth: 2
+
+   .compiledWithFilesystem() <compiledWithFilesystem>
+   .compiledWithMultithreading() <compiledWithMultithreading>
+   .compiledWithFFmpeg() <compiledWithFFmpeg>
+   .compiledWithFFmpegLinkStatic() <compiledWithFFmpegLinkStatic>
+   .compiledWithFFmpegBuildLinkStatic() <compiledWithFFmpegBuildLinkStatic>
+   .copyrightLicenseSPDX() <copyrightLicenseSPDX>
+   .babycatVersion() <babycatVersion>
+

--- a/docs/source/api/wasm/index.rst
+++ b/docs/source/api/wasm/index.rst
@@ -5,6 +5,7 @@ Babycat WebAssembly API Documentation
    :maxdepth: 1
    :hidden:
 
+   BuildInfo <BuildInfo/index>
    Waveform <Waveform/index>
 
 - :doc:`Waveform/index`

--- a/src/backend/build_info.rs
+++ b/src/backend/build_info.rs
@@ -1,23 +1,34 @@
+//! Information about compile-time features and licensing.
+
+/// Returns `true` if Babycat was compiled with support for
+/// reading and writing files from/to the local filesystem.
 #[inline(always)]
 pub fn compiled_with_filesystem() -> bool {
     cfg!(feature = "enable-filesystem")
 }
 
+/// Returns `true` if Babycat was compiled with multithreading support.
 #[inline(always)]
 pub fn compiled_with_multithreading() -> bool {
     cfg!(feature = "enable-multithreading")
 }
 
+/// Returns `true` if Babycat was compiled with FFmpeg support enabled.
+///
+/// This function will return `true` no matter how
+/// FFmpeg was compiled or linked to Babycat.
 #[inline(always)]
 pub fn compiled_with_ffmpeg() -> bool {
     cfg!(feature = "enable-ffmpeg")
 }
 
+/// Returns `true` if Babycat was statically linked to an existing copy of FFmpeg.
 #[inline(always)]
 pub fn compiled_with_ffmpeg_link_static() -> bool {
     cfg!(feature = "enable-ffmpeg-link-static")
 }
 
+/// Returns `true` if Babycat compiled its own copy of FFmpeg.
 #[inline(always)]
 pub fn compiled_with_ffmpeg_build_link_static() -> bool {
     cfg!(feature = "enable-ffmpeg-build-link-static")
@@ -26,6 +37,10 @@ pub fn compiled_with_ffmpeg_build_link_static() -> bool {
 const MIT_LICENSE: &str = "MIT";
 const LGPL_2_1_OR_LATER_LICENSE: &str = "LGPL-2.1+";
 
+/// The copyright license for this version of Babycat.
+///
+/// This could change based on which features or libraries
+/// were compiled into Babycat.
 #[inline(always)]
 pub fn copyright_license_spdx() -> &'static str {
     if cfg!(feature = "enable-ffmpeg") {
@@ -34,6 +49,10 @@ pub fn copyright_license_spdx() -> &'static str {
     MIT_LICENSE
 }
 
+/// The current Babycat version.
+///
+/// This function returns `"0.0.0"` for development versions
+/// of Babycat.
 #[inline(always)]
 pub fn babycat_version() -> &'static str {
     option_env!("CARGO_PKG_VERSION").unwrap_or("0.0.0")

--- a/src/backend/constants.rs
+++ b/src/backend/constants.rs
@@ -33,6 +33,7 @@ pub const RESAMPLE_MODE_BABYCAT_SINC: u32 = 3;
 pub const DECODING_BACKEND_SYMPHONIA: u32 = 1;
 
 /// Sets the decoding backend as [`FFmpegDecoder`](crate::ffmpeg::FFmpegDecoder).
+#[allow(dead_code)]
 pub const DECODING_BACKEND_FFMPEG: u32 = 2;
 
 /// The default number of threads to use for multithreaded operations.

--- a/src/backend/ffmpeg/decoder.rs
+++ b/src/backend/ffmpeg/decoder.rs
@@ -20,7 +20,7 @@ use crate::backend::Source;
 #[inline(always)]
 fn new_input_for_file<F: Clone + AsRef<Path>>(filename: F) -> Result<Input, Error> {
     let filename_ref = filename.as_ref();
-    ffmpeg::format::input(&filename_ref).map_err(|err| match err {
+    ffmpeg_next::format::input(&filename_ref).map_err(|err| match err {
         // File not found error. Audio filename was not found on the local filesystem.
         FFmpegError::Other { errno: ENOENT } => Error::FileNotFound(Box::leak(
             filename_ref.to_str().unwrap().to_owned().into_boxed_str(),
@@ -34,7 +34,7 @@ fn get_first_working_audio_stream(input: &Input) -> Result<(Stream, AudioDecoder
     let mut num_found_streams = 0;
     for input_stream in input.streams() {
         num_found_streams += 1;
-        match ffmpeg::codec::context::Context::from_parameters(input_stream.parameters()) {
+        match ffmpeg_next::codec::context::Context::from_parameters(input_stream.parameters()) {
             Err(_) => continue,
             Ok(codec_context) => match codec_context.decoder().audio() {
                 Err(_) => continue,
@@ -68,7 +68,10 @@ fn estimate_num_frames_inner(
 }
 
 #[inline(always)]
-pub fn estimate_num_frames(stream: &ffmpeg::Stream, decoder: &ffmpeg::decoder::Audio) -> usize {
+pub fn estimate_num_frames(
+    stream: &ffmpeg_next::Stream,
+    decoder: &ffmpeg_next::decoder::Audio,
+) -> usize {
     let stream_duration = stream.duration();
     let stream_tb = stream.time_base();
     let decoder_tb = decoder.time_base();

--- a/src/backend/ffmpeg/init.rs
+++ b/src/backend/ffmpeg/init.rs
@@ -7,7 +7,7 @@ static FFMPEG_INIT: Once = Once::new();
 #[inline(always)]
 pub fn ffmpeg_init() {
     FFMPEG_INIT.call_once(|| {
-        ffmpeg::init().unwrap();
-        ffmpeg::util::log::set_level(Quiet);
+        ffmpeg_next::init().unwrap();
+        ffmpeg_next::util::log::set_level(Quiet);
     });
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,7 +1,4 @@
 #[cfg(all(feature = "enable-filesystem", feature = "enable-ffmpeg"))]
-extern crate ffmpeg_next;
-
-#[cfg(all(feature = "enable-filesystem", feature = "enable-ffmpeg"))]
 pub mod ffmpeg;
 
 #[cfg(all(feature = "enable-multithreading", feature = "enable-filesystem"))]

--- a/src/frontends/c/build_info.rs
+++ b/src/frontends/c/build_info.rs
@@ -3,36 +3,58 @@ use std::os::raw::c_char;
 
 use crate::backend::build_info::*;
 
+/// Returns `true` if Babycat was compiled with support for
+/// reading and writing files to/from the local filesystem.
+///
+///
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_build_info_compiled_with_filesystem() -> bool {
     compiled_with_filesystem()
 }
 
+/// Returns `true` if Babycat was compiled with multithreading support.
+///
+///
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_build_info_compiled_with_multithreading() -> bool {
     compiled_with_multithreading()
 }
 
+/// Returns `true` if Babycat was compiled with FFmpeg support enabled.
+///
+/// This function will return `true` no matter how FFmpeg was compiled
+/// or linked to Babycat.
+///
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_build_info_compiled_with_ffmpeg() -> bool {
     compiled_with_ffmpeg()
 }
 
+/// Returns `true` if Babycat was statically linked to an existing copy of FFmpeg.
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_build_info_compiled_with_ffmpeg_link_static() -> bool {
     compiled_with_ffmpeg_link_static()
 }
 
+/// Returns `true` if Babycat compiled its own copy of FFmpeg.
+///
+///
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_build_info_compiled_with_ffmpeg_build_link_static() -> bool {
     compiled_with_ffmpeg_build_link_static()
 }
 
+/// The copyright license for this version of Babycat.
+///
+/// Babycat's license can vary based on which features or libraries were
+/// compiled into Babycat.
+///
+///
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_build_info_copyright_license_spdx() -> *const c_char {
@@ -40,6 +62,11 @@ pub unsafe extern "C" fn babycat_build_info_copyright_license_spdx() -> *const c
     c_string.as_ptr()
 }
 
+/// The current Babycat version.
+///
+/// This function returns `"0.0.0"` for development versions
+/// of Babycat.
+///
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_build_info_version() -> *const c_char {

--- a/src/frontends/python/build_info.rs
+++ b/src/frontends/python/build_info.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
+/// Returns ``True`` if Babycat was compiled with support for
+/// reading and writing files from/to the local filesystem.
 #[pyfunction()]
 #[pyo3(text_signature = "()")]
 #[allow(clippy::too_many_arguments)]
@@ -8,6 +10,7 @@ pub fn compiled_with_filesystem() -> bool {
     crate::backend::build_info::compiled_with_filesystem()
 }
 
+/// Returns ``True`` if Babycat was compiled with multithreading support.
 #[pyfunction()]
 #[pyo3(text_signature = "()")]
 #[allow(clippy::too_many_arguments)]
@@ -15,6 +18,10 @@ pub fn compiled_with_multithreading() -> bool {
     crate::backend::build_info::compiled_with_multithreading()
 }
 
+/// Returns ``True`` if Babycat was compiled with FFmpeg support enabled.
+///
+/// This function will return ``True`` no matter how
+/// FFmpeg was compiled or linked to Babycat.
 #[pyfunction()]
 #[pyo3(text_signature = "()")]
 #[allow(clippy::too_many_arguments)]
@@ -22,6 +29,7 @@ pub fn compiled_with_ffmpeg() -> bool {
     crate::backend::build_info::compiled_with_ffmpeg()
 }
 
+/// Returns ``True`` if Babycat was statically linked to an existing copy of FFmpeg.
 #[pyfunction()]
 #[pyo3(text_signature = "()")]
 #[allow(clippy::too_many_arguments)]
@@ -29,6 +37,7 @@ pub fn compiled_with_ffmpeg_link_static() -> bool {
     crate::backend::build_info::compiled_with_ffmpeg_link_static()
 }
 
+/// Returns ``true`` if Babycat compiled its own copy of FFmpeg.
 #[pyfunction()]
 #[pyo3(text_signature = "()")]
 #[allow(clippy::too_many_arguments)]
@@ -36,6 +45,10 @@ pub fn compiled_with_ffmpeg_build_link_static() -> bool {
     crate::backend::build_info::compiled_with_ffmpeg_build_link_static()
 }
 
+/// The copyright license for this version of Babycat.
+///
+/// This could change based on which features or libraries
+/// were compiled into Babycat.
 #[pyfunction()]
 #[pyo3(text_signature = "()")]
 #[allow(clippy::too_many_arguments)]
@@ -43,6 +56,10 @@ pub fn copyright_license_spdx() -> &'static str {
     crate::backend::build_info::copyright_license_spdx()
 }
 
+/// The current Babycat version.
+///
+/// This function returns `"0.0.0"` for development versions
+/// of Babycat.
 #[pyfunction()]
 #[pyo3(text_signature = "()")]
 #[allow(clippy::too_many_arguments)]
@@ -56,7 +73,7 @@ pub fn make_build_info_submodule(py: Python) -> PyResult<&PyModule> {
     build_info_submodule.setattr(
         "__doc__",
         "
-Various build-time constants.
+Information about compile-time features and licensing.
 ",
     )?;
 

--- a/src/frontends/wasm/build_info.rs
+++ b/src/frontends/wasm/build_info.rs
@@ -2,6 +2,8 @@
 
 use wasm_bindgen::prelude::*;
 
+/// Returns ``true`` if Babycat was compiled with support for
+/// reading and writing files from/to the local filesystem.
 #[allow(clippy::unused_unit)]
 #[wasm_bindgen]
 pub struct BuildInfo {}
@@ -9,30 +11,46 @@ pub struct BuildInfo {}
 #[allow(clippy::unused_unit)]
 #[wasm_bindgen]
 impl BuildInfo {
+    /// Returns ``true`` if Babycat was compiled with multithreading support.
     pub fn compiledWithFilesystem() -> bool {
         crate::backend::build_info::compiled_with_filesystem()
     }
 
+    /// Returns ``true`` if Babycat was compiled with multithreading support.
     pub fn compiledWithMultithreading() -> bool {
         crate::backend::build_info::compiled_with_multithreading()
     }
 
+    /// Returns ``true`` if Babycat was compiled with FFmpeg support enabled.
+    ///
+    /// This function will return ``true`` no matter how
+    /// FFmpeg was compiled or linked to Babycat.
     pub fn compiledWithFFmpeg() -> bool {
         crate::backend::build_info::compiled_with_ffmpeg()
     }
 
+    /// Returns ``true`` if Babycat was statically linked to an existing copy of FFmpeg.
     pub fn compiledWithFFmpegLinkStatic() -> bool {
         crate::backend::build_info::compiled_with_ffmpeg_link_static()
     }
 
+    /// Returns ``true`` if Babycat compiled its own copy of FFmpeg.
     pub fn compiledWithFFpegBuildLinkStatic() -> bool {
         crate::backend::build_info::compiled_with_ffmpeg_build_link_static()
     }
 
+    /// The copyright license for this version of Babycat.
+    ///
+    /// This could change based on which features or libraries
+    /// were compiled into Babycat.
     pub fn copyrightLicenseSPDX() -> String {
         crate::backend::build_info::copyright_license_spdx().into()
     }
 
+    /// The current Babycat version.
+    ///
+    /// This function returns ``"0.0.0"`` for development versions
+    /// of Babycat.
     pub fn babycatVersion() -> String {
         crate::backend::build_info::babycat_version().into()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,9 +111,6 @@ macro_rules! leak_str {
     };
 }
 
-#[cfg(all(feature = "enable-filesystem", feature = "enable-ffmpeg"))]
-extern crate ffmpeg_next as ffmpeg;
-
 mod backend;
 
 // Compile the Rust frontend if we're building a command-line


### PR DESCRIPTION
The `build_info` functions provide information about which features
were included at compile-time. This PR adds rustdoc and Sphinx
documentation for these functions.
p
