### PR TITLE
Enable pedantic clippy lints. Stop using `inline(always)`

### DIFF
--- a/src/backend/batch.rs
+++ b/src/backend/batch.rs
@@ -74,6 +74,7 @@ use crate::backend::WaveformNamedResult;
 /// );
 /// ```
 #[allow(dead_code)] // Silence dead code warning because we do not use this function in the C frontend.
+#[allow(clippy::missing_panics_doc)]
 pub fn waveforms_from_files(
     filenames: &[&str],
     waveform_args: WaveformArgs,

--- a/src/backend/build_info.rs
+++ b/src/backend/build_info.rs
@@ -2,13 +2,13 @@
 
 /// Returns `true` if Babycat was compiled with support for
 /// reading and writing files from/to the local filesystem.
-#[inline(always)]
+#[inline]
 pub fn compiled_with_filesystem() -> bool {
     cfg!(feature = "enable-filesystem")
 }
 
 /// Returns `true` if Babycat was compiled with multithreading support.
-#[inline(always)]
+#[inline]
 pub fn compiled_with_multithreading() -> bool {
     cfg!(feature = "enable-multithreading")
 }
@@ -17,19 +17,19 @@ pub fn compiled_with_multithreading() -> bool {
 ///
 /// This function will return `true` no matter how
 /// FFmpeg was compiled or linked to Babycat.
-#[inline(always)]
+#[inline]
 pub fn compiled_with_ffmpeg() -> bool {
     cfg!(feature = "enable-ffmpeg")
 }
 
 /// Returns `true` if Babycat was statically linked to an existing copy of FFmpeg.
-#[inline(always)]
+#[inline]
 pub fn compiled_with_ffmpeg_link_static() -> bool {
     cfg!(feature = "enable-ffmpeg-link-static")
 }
 
 /// Returns `true` if Babycat compiled its own copy of FFmpeg.
-#[inline(always)]
+#[inline]
 pub fn compiled_with_ffmpeg_build_link_static() -> bool {
     cfg!(feature = "enable-ffmpeg-build-link-static")
 }
@@ -41,7 +41,7 @@ const LGPL_2_1_OR_LATER_LICENSE: &str = "LGPL-2.1+";
 ///
 /// This could change based on which features or libraries
 /// were compiled into Babycat.
-#[inline(always)]
+#[inline]
 pub fn copyright_license_spdx() -> &'static str {
     if cfg!(feature = "enable-ffmpeg") {
         return LGPL_2_1_OR_LATER_LICENSE;
@@ -53,7 +53,7 @@ pub fn copyright_license_spdx() -> &'static str {
 ///
 /// This function returns `"0.0.0"` for development versions
 /// of Babycat.
-#[inline(always)]
+#[inline]
 pub fn babycat_version() -> &'static str {
     option_env!("CARGO_PKG_VERSION").unwrap_or("0.0.0")
 }

--- a/src/backend/decoder.rs
+++ b/src/backend/decoder.rs
@@ -7,7 +7,10 @@ use std::io::Read;
 use std::marker::Send;
 use std::marker::Sync;
 
-use crate::backend::constants::*;
+use crate::backend::constants::{
+    DECODING_BACKEND_FFMPEG, DECODING_BACKEND_SYMPHONIA, DEFAULT_DECODING_BACKEND,
+    DEFAULT_FILE_EXTENSION, DEFAULT_MIME_TYPE,
+};
 use crate::backend::errors::Error;
 use crate::backend::signal::Signal;
 use crate::backend::Source;
@@ -18,19 +21,19 @@ pub trait Decoder: Signal {
 }
 
 impl Decoder for Box<dyn Decoder> {
-    #[inline(always)]
+    #[inline]
     fn begin(&mut self) -> Result<Box<dyn Source + '_>, Error> {
         (&mut **self).begin()
     }
 }
 
 impl Signal for Box<dyn Decoder> {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         (&**self).frame_rate_hz()
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_channels(&self) -> u16 {
         (&**self).num_channels()
     }
@@ -99,6 +102,7 @@ pub fn from_file<F: Clone + AsRef<Path>>(
     decoding_backend: u32,
     filename: F,
 ) -> Result<Box<dyn Decoder>, Error> {
+    #[allow(clippy::match_same_arms)]
     match decoding_backend {
         DEFAULT_DECODING_BACKEND => {
             #[cfg(feature = "enable-ffmpeg")]

--- a/src/backend/ffmpeg/init.rs
+++ b/src/backend/ffmpeg/init.rs
@@ -4,7 +4,8 @@ use ffmpeg_next::util::log::level::Level::Quiet;
 
 static FFMPEG_INIT: Once = Once::new();
 
-#[inline(always)]
+#[allow(clippy::missing_panics_doc)]
+#[inline]
 pub fn ffmpeg_init() {
     FFMPEG_INIT.call_once(|| {
         ffmpeg_next::init().unwrap();

--- a/src/backend/ffmpeg/source.rs
+++ b/src/backend/ffmpeg/source.rs
@@ -10,7 +10,7 @@ use crate::backend::Sample;
 use crate::backend::Signal;
 use crate::backend::Source;
 
-#[inline(always)]
+#[inline]
 fn next_packet<'a>(
     packet_iter: &mut PacketIter<'a>,
     decoder: &mut AudioDecoder,
@@ -24,7 +24,7 @@ fn next_packet<'a>(
     None
 }
 
-#[inline(always)]
+#[inline]
 fn next_decoded_frame_and_len(decoder: &mut AudioDecoder) -> (Option<Frame>, usize) {
     let mut frame = Frame::empty();
     if decoder.receive_frame(&mut frame).is_err() {
@@ -34,7 +34,7 @@ fn next_decoded_frame_and_len(decoder: &mut AudioDecoder) -> (Option<Frame>, usi
     (Some(frame), frame_len)
 }
 
-#[inline(always)]
+#[inline]
 fn get_sample_packed<T: Sample>(
     frame: &Frame,
     num_channels: usize,
@@ -51,7 +51,7 @@ fn get_sample_packed<T: Sample>(
     }
 }
 
-#[inline(always)]
+#[inline]
 fn get_sample_planar<T: Sample>(frame: &Frame, frame_idx: usize, channel_idx: usize) -> f32 {
     unsafe {
         // When audio is stored in a "planar" format, FFmpeg
@@ -118,17 +118,17 @@ impl<'a, T: Sample, const PACKED: bool> FFmpegSource<'a, T, PACKED> {
 impl<'a, T: Sample, const PACKED: bool> Source for FFmpegSource<'a, T, PACKED> {}
 
 impl<'a, T: Sample, const PACKED: bool> Signal for FFmpegSource<'a, T, PACKED> {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         self.frame_rate_hz
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_channels(&self) -> u16 {
         self.num_channels
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_frames_estimate(&self) -> Option<usize> {
         match self.est_num_frames {
             None => None,
@@ -145,7 +145,7 @@ impl<'a, T: Sample, const PACKED: bool> Signal for FFmpegSource<'a, T, PACKED> {
 impl<'a, T: Sample, const PACKED: bool> Iterator for FFmpegSource<'a, T, PACKED> {
     type Item = f32;
 
-    #[inline(always)]
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self.est_num_frames {
             None => (0, None),
@@ -161,7 +161,7 @@ impl<'a, T: Sample, const PACKED: bool> Iterator for FFmpegSource<'a, T, PACKED>
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             match (&mut self.packet, &mut self.frame, self.sent_eof) {

--- a/src/backend/resample/babycat_lanczos.rs
+++ b/src/backend/resample/babycat_lanczos.rs
@@ -23,6 +23,9 @@ fn lanczos_kernel(x: f32, a: f32) -> f32 {
     0.0
 }
 
+#[allow(clippy::cast_precision_loss)]
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
 fn compute_sample(
     input_audio: &[f32],
     frame_idx: f32,
@@ -38,12 +41,13 @@ fn compute_sample(
     for i in i_start..i_end {
         if (i as usize) < num_input_frames {
             the_sample += get(input_audio, i as usize, channel_idx, num_channels)
-                * lanczos_kernel(frame_idx - i as f32, a)
+                * lanczos_kernel(frame_idx - i as f32, a);
         }
     }
     the_sample
 }
 
+#[allow(clippy::cast_precision_loss)]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,

--- a/src/backend/resample/babycat_sinc.rs
+++ b/src/backend/resample/babycat_sinc.rs
@@ -11,8 +11,12 @@ use crate::backend::{
 };
 
 #[allow(clippy::excessive_precision)]
+#[allow(clippy::unreadable_literal)]
 const KAISER_BEST_WINDOW: [f32; 32769] = include!("kaiser_best.txt");
 
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+#[allow(clippy::cast_precision_loss)]
 pub fn resample(
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,
@@ -21,7 +25,8 @@ pub fn resample(
 ) -> Result<Vec<f32>, Error> {
     validate_args(input_frame_rate_hz, output_frame_rate_hz, num_channels)?;
 
-    let sample_ratio: f32 = (output_frame_rate_hz as f32) / (input_frame_rate_hz as f32);
+    let sample_ratio: f32 =
+        (f64::from(output_frame_rate_hz) / f64::from(input_frame_rate_hz as f32)) as f32;
 
     let num_output_frames = get_num_output_frames(
         input_audio,
@@ -51,7 +56,7 @@ pub fn resample(
         input_audio,
         &mut ret,
         num_channels as usize,
-        (output_frame_rate_hz as f64) / (input_frame_rate_hz as f64),
+        f64::from(output_frame_rate_hz) / f64::from(input_frame_rate_hz),
         &interp_win,
         &interp_delta,
         precision,
@@ -60,6 +65,9 @@ pub fn resample(
     Ok(ret)
 }
 
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+#[allow(clippy::cast_precision_loss)]
 fn resample_f(
     in_audio: &[f32],
     out_audio: &mut [f32],
@@ -73,7 +81,7 @@ fn resample_f(
 
     // equal to (in_audio_hz / out_audio_hz)
     let time_increment = 1.0 / sample_ratio;
-    let index_step = (scale * num_table as f64) as usize;
+    let index_step = (scale * f64::from(num_table)) as usize;
 
     let n_win = interp_win.len();
     let n_in_frames = in_audio.len() / (num_channels);
@@ -84,7 +92,7 @@ fn resample_f(
         let in_frame_idx = time_register as usize;
 
         let frac: f64 = scale * time_register.fract();
-        let index_frac = frac * num_table as f64;
+        let index_frac = frac * f64::from(num_table);
         let offset = index_frac as usize;
         let eta = index_frac.fract() as f32;
 
@@ -101,7 +109,7 @@ fn resample_f(
 
         // Right wing of response
         let frac = scale - frac;
-        let index_frac = frac * num_table as f64;
+        let index_frac = frac * f64::from(num_table);
         let offset = index_frac as usize;
         let eta = index_frac.fract() as f32;
 

--- a/src/backend/resample/common.rs
+++ b/src/backend/resample/common.rs
@@ -26,14 +26,14 @@ pub fn validate_args(
         return Err(Error::ResamplingError);
     }
     if (input_frame_rate_hz > output_frame_rate_hz)
-        && (input_frame_rate_hz as f64 / output_frame_rate_hz as f64 > 256.0)
+        && (f64::from(input_frame_rate_hz) / f64::from(output_frame_rate_hz) > 256.0)
     {
         return Err(Error::WrongFrameRateRatio(
             input_frame_rate_hz,
             output_frame_rate_hz,
         ));
     }
-    if output_frame_rate_hz as f64 / input_frame_rate_hz as f64 > 256.0 {
+    if f64::from(output_frame_rate_hz) / f64::from(input_frame_rate_hz) > 256.0 {
         return Err(Error::WrongFrameRateRatio(
             input_frame_rate_hz,
             output_frame_rate_hz,
@@ -42,13 +42,17 @@ pub fn validate_args(
     Ok(())
 }
 
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_precision_loss)]
+#[allow(clippy::cast_sign_loss)]
 pub fn get_num_output_frames(
     input_audio: &[f32],
     input_frame_rate_hz: u32,
     output_frame_rate_hz: u32,
     num_channels: u16,
 ) -> usize {
-    ((input_audio.len() as f64 * output_frame_rate_hz as f64 / input_frame_rate_hz as f64).ceil()
-        / num_channels as f64)
-        .ceil() as usize
+    ((input_audio.len() as f64 * f64::from(output_frame_rate_hz) / f64::from(input_frame_rate_hz))
+        .ceil()
+        / f64::from(num_channels))
+    .ceil() as usize
 }

--- a/src/backend/sample.rs
+++ b/src/backend/sample.rs
@@ -4,33 +4,37 @@ pub trait Sample: Copy + Debug + Display + Sized + PartialOrd + PartialEq {
     fn as_f32_sample(self) -> f32;
 }
 
+#[allow(clippy::cast_precision_loss)]
 const I16_DENOM: f32 = ((i16::MAX as i32) + 1_i32) as f32;
 
 impl Sample for i16 {
-    #[inline(always)]
+    #[inline]
     fn as_f32_sample(self) -> f32 {
-        (self as f32) / I16_DENOM
+        f32::from(self) / I16_DENOM
     }
 }
 
+#[allow(clippy::cast_precision_loss)]
 const I32_DENOM: f64 = ((i32::MAX as i64) + 1_i64) as f64;
 
 impl Sample for i32 {
-    #[inline(always)]
+    #[inline]
+    #[allow(clippy::cast_possible_truncation)]
     fn as_f32_sample(self) -> f32 {
-        ((self as f64) / I32_DENOM) as f32
+        (f64::from(self) / I32_DENOM) as f32
     }
 }
 
 impl Sample for f32 {
-    #[inline(always)]
+    #[inline]
     fn as_f32_sample(self) -> f32 {
         self
     }
 }
 
 impl Sample for f64 {
-    #[inline(always)]
+    #[inline]
+    #[allow(clippy::cast_possible_truncation)]
     fn as_f32_sample(self) -> f32 {
         self as f32
     }

--- a/src/backend/source/convert_to_mono.rs
+++ b/src/backend/source/convert_to_mono.rs
@@ -8,9 +8,10 @@ pub struct ConvertToMono<S: Source> {
 }
 
 impl<S: Source> ConvertToMono<S> {
-    #[inline(always)]
+    #[inline]
     pub fn new(iter: S) -> Self {
         let iter_num_channels_usize: usize = iter.num_channels() as usize;
+        #[allow(clippy::cast_precision_loss)]
         let iter_num_channels_f32: f32 = iter_num_channels_usize as f32;
         Self {
             iter,
@@ -23,17 +24,17 @@ impl<S: Source> ConvertToMono<S> {
 impl<S: Source> Source for ConvertToMono<S> {}
 
 impl<S: Source> Signal for ConvertToMono<S> {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         self.iter.frame_rate_hz()
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_channels(&self) -> u16 {
         1
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_frames_estimate(&self) -> Option<usize> {
         self.iter.num_frames_estimate()
     }
@@ -42,7 +43,7 @@ impl<S: Source> Signal for ConvertToMono<S> {
 impl<S: Source> Iterator for ConvertToMono<S> {
     type Item = f32;
 
-    #[inline(always)]
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self.iter.size_hint() {
             (min, None) => (min / self.iter_num_channels_usize, None),
@@ -53,7 +54,7 @@ impl<S: Source> Iterator for ConvertToMono<S> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let mut psum: f32 = 0.0_f32;
         for _ in 0..self.iter_num_channels_usize {

--- a/src/backend/source/mod.rs
+++ b/src/backend/source/mod.rs
@@ -14,7 +14,7 @@ use crate::backend::signal::Signal;
 
 /// A sample iterator created by an audio decoder.
 pub trait Source: Signal + Iterator<Item = f32> {
-    #[inline(always)]
+    #[inline]
     fn skip_samples(self, count: usize) -> SkipSamples<Self>
     where
         Self: Sized,
@@ -22,7 +22,7 @@ pub trait Source: Signal + Iterator<Item = f32> {
         SkipSamples::new(self, count)
     }
 
-    #[inline(always)]
+    #[inline]
     fn take_samples(self, count: usize) -> TakeSamples<Self>
     where
         Self: Sized,
@@ -30,7 +30,7 @@ pub trait Source: Signal + Iterator<Item = f32> {
         TakeSamples::new(self, count)
     }
 
-    #[inline(always)]
+    #[inline]
     fn select_first_channels(self, selected_num_channels: u16) -> SelectChannels<Self>
     where
         Self: Sized,
@@ -38,7 +38,7 @@ pub trait Source: Signal + Iterator<Item = f32> {
         SelectChannels::new(self, selected_num_channels)
     }
 
-    #[inline(always)]
+    #[inline]
     fn convert_to_mono(self) -> ConvertToMono<Self>
     where
         Self: Sized,
@@ -50,17 +50,17 @@ pub trait Source: Signal + Iterator<Item = f32> {
 impl Source for Box<dyn Source + '_> {}
 
 impl Signal for Box<dyn Source + '_> {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         (&**self).frame_rate_hz()
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_channels(&self) -> u16 {
         (&**self).num_channels()
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_frames_estimate(&self) -> Option<usize> {
         (&**self).num_frames_estimate()
     }

--- a/src/backend/source/select_channels.rs
+++ b/src/backend/source/select_channels.rs
@@ -26,17 +26,19 @@ impl<S: Source> SelectChannels<S> {
 impl<S: Source> Source for SelectChannels<S> {}
 
 impl<S: Source> Signal for SelectChannels<S> {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         self.iter.frame_rate_hz()
     }
 
-    #[inline(always)]
+    #[inline]
+    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_possible_truncation)]
     fn num_channels(&self) -> u16 {
         self.selected_num_channels as u16
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_frames_estimate(&self) -> Option<usize> {
         self.iter.num_frames_estimate()
     }
@@ -45,7 +47,7 @@ impl<S: Source> Signal for SelectChannels<S> {
 impl<S: Source> Iterator for SelectChannels<S> {
     type Item = f32;
 
-    #[inline(always)]
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, upper) = self.iter.size_hint();
         let lower = (lower * self.selected_num_channels + self.original_num_channels - 1)

--- a/src/backend/source/skip_samples.rs
+++ b/src/backend/source/skip_samples.rs
@@ -7,7 +7,7 @@ pub struct SkipSamples<S: Source> {
 }
 
 impl<S: Source> SkipSamples<S> {
-    #[inline(always)]
+    #[inline]
     pub fn new(iter: S, count: usize) -> Self {
         Self { iter, count }
     }
@@ -16,17 +16,17 @@ impl<S: Source> SkipSamples<S> {
 impl<S: Source> Source for SkipSamples<S> {}
 
 impl<S: Source> Signal for SkipSamples<S> {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         self.iter.frame_rate_hz()
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_channels(&self) -> u16 {
         self.iter.num_channels()
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_frames_estimate(&self) -> Option<usize> {
         self.iter.num_frames_estimate()
     }
@@ -35,7 +35,7 @@ impl<S: Source> Signal for SkipSamples<S> {
 impl<S: Source> Iterator for SkipSamples<S> {
     type Item = f32;
 
-    #[inline(always)]
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.count == 0 {
             return self.iter.size_hint();
@@ -46,7 +46,7 @@ impl<S: Source> Iterator for SkipSamples<S> {
         (lower, upper)
     }
 
-    #[inline(always)]
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         while self.count > 0 {
             self.iter.next();

--- a/src/backend/source/take_samples.rs
+++ b/src/backend/source/take_samples.rs
@@ -7,7 +7,7 @@ pub struct TakeSamples<S: Source> {
 }
 
 impl<S: Source> TakeSamples<S> {
-    #[inline(always)]
+    #[inline]
     pub fn new(iter: S, count: usize) -> Self {
         Self { iter, count }
     }
@@ -16,17 +16,17 @@ impl<S: Source> TakeSamples<S> {
 impl<S: Source> Source for TakeSamples<S> {}
 
 impl<S: Source> Signal for TakeSamples<S> {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         self.iter.frame_rate_hz()
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_channels(&self) -> u16 {
         self.iter.num_channels()
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_frames_estimate(&self) -> Option<usize> {
         self.iter.num_frames_estimate()
     }
@@ -35,7 +35,7 @@ impl<S: Source> Signal for TakeSamples<S> {
 impl<S: Source> Iterator for TakeSamples<S> {
     type Item = f32;
 
-    #[inline(always)]
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         if self.count == 0 {
             return (0, Some(0));
@@ -49,7 +49,7 @@ impl<S: Source> Iterator for TakeSamples<S> {
         (lower, upper)
     }
 
-    #[inline(always)]
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.count == 0 {
             return None;

--- a/src/backend/source/waveform_source.rs
+++ b/src/backend/source/waveform_source.rs
@@ -21,17 +21,17 @@ impl<'a> WaveformSource<'a> {
 impl<'a> Source for WaveformSource<'a> {}
 
 impl<'a> Signal for WaveformSource<'a> {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         self.frame_rate_hz
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_channels(&self) -> u16 {
         self.num_channels
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_frames_estimate(&self) -> Option<usize> {
         let remaining_samples: usize = self.interleaved_samples.len() - self.current_sample;
         Some(remaining_samples / self.num_channels as usize)
@@ -41,13 +41,13 @@ impl<'a> Signal for WaveformSource<'a> {
 impl<'a> Iterator for WaveformSource<'a> {
     type Item = f32;
 
-    #[inline(always)]
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let diff = self.interleaved_samples.len() - self.current_sample;
         (diff, Some(diff))
     }
 
-    #[inline(always)]
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_sample >= self.interleaved_samples.len() {
             return None;
@@ -57,7 +57,7 @@ impl<'a> Iterator for WaveformSource<'a> {
         retval
     }
 
-    #[inline(always)]
+    #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         self.current_sample += n;
         self.next()

--- a/src/backend/symphonia/decoder.rs
+++ b/src/backend/symphonia/decoder.rs
@@ -31,6 +31,7 @@ pub struct SymphoniaDecoder {
 }
 
 impl SymphoniaDecoder {
+    #[allow(clippy::missing_panics_doc)]
     pub fn from_encoded_stream_with_hint<R: 'static + Read + Send + Sync>(
         encoded_stream: R,
         file_extension: &str,
@@ -88,8 +89,10 @@ impl SymphoniaDecoder {
 
         // Examine the actual shape of this audio file.
         let frame_rate_hz = default_track.codec_params.sample_rate.unwrap();
+        #[allow(clippy::cast_possible_truncation)]
         let num_channels = default_track.codec_params.channels.unwrap().count() as u16;
 
+        #[allow(clippy::cast_possible_truncation)]
         let est_num_frames: Option<usize> = default_track
             .codec_params
             .n_frames
@@ -104,6 +107,7 @@ impl SymphoniaDecoder {
     }
 
     #[cfg(feature = "enable-filesystem")]
+    #[allow(clippy::missing_panics_doc)]
     pub fn from_file<F: Clone + AsRef<Path>>(filename: F) -> Result<Box<dyn Decoder>, Error> {
         let filename_ref = filename.as_ref();
         let file = match std::fs::File::open(filename_ref) {
@@ -139,7 +143,7 @@ impl SymphoniaDecoder {
 }
 
 impl Decoder for SymphoniaDecoder {
-    #[inline(always)]
+    #[inline]
     fn begin(&mut self) -> Result<Box<dyn Source + '_>, Error> {
         let decode_iter = SymphoniaSource::new(
             &mut self.reader,
@@ -152,17 +156,17 @@ impl Decoder for SymphoniaDecoder {
 }
 
 impl Signal for SymphoniaDecoder {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         self.frame_rate_hz
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_channels(&self) -> u16 {
         self.num_channels
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_frames_estimate(&self) -> Option<usize> {
         self.est_num_frames
     }

--- a/src/backend/symphonia/source.rs
+++ b/src/backend/symphonia/source.rs
@@ -75,7 +75,7 @@ impl<'a> SymphoniaSource<'a> {
                 }
 
                 Ok(decoded) => {
-                    let spec = decoded.spec().to_owned();
+                    let spec = *decoded.spec();
                     let duration = decoded.capacity() as u64;
                     let mut buffer = SampleBuffer::<f32>::new(duration, spec);
                     buffer.copy_interleaved_ref(decoded);
@@ -90,17 +90,17 @@ impl<'a> SymphoniaSource<'a> {
 impl<'a> Source for SymphoniaSource<'a> {}
 
 impl<'a> Signal for SymphoniaSource<'a> {
-    #[inline(always)]
+    #[inline]
     fn frame_rate_hz(&self) -> u32 {
         self.frame_rate_hz
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_channels(&self) -> u16 {
         self.num_channels
     }
 
-    #[inline(always)]
+    #[inline]
     fn num_frames_estimate(&self) -> Option<usize> {
         match self.est_num_frames {
             None => None,
@@ -118,7 +118,7 @@ impl<'a> Signal for SymphoniaSource<'a> {
 impl<'a> Iterator for SymphoniaSource<'a> {
     type Item = f32;
 
-    #[inline(always)]
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self.est_num_frames {
             None => (0, None),
@@ -132,7 +132,7 @@ impl<'a> Iterator for SymphoniaSource<'a> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let buffer = self.current_packet_audio_buffer.as_ref()?;

--- a/src/backend/waveform.rs
+++ b/src/backend/waveform.rs
@@ -6,7 +6,11 @@ use std::marker::Sync;
 use serde::{Deserialize, Serialize};
 
 use crate::backend::common::milliseconds_to_frames;
-use crate::backend::constants::*;
+//use crate::backend::constants::*;
+use crate::backend::constants::{
+    DEFAULT_END_TIME_MILLISECONDS, DEFAULT_FRAME_RATE_HZ, DEFAULT_NUM_CHANNELS,
+    DEFAULT_RESAMPLE_MODE, DEFAULT_START_TIME_MILLISECONDS,
+};
 use crate::backend::decoder::from_encoded_bytes;
 use crate::backend::decoder::from_encoded_bytes_with_hint;
 use crate::backend::decoder::from_encoded_stream;
@@ -623,7 +627,7 @@ mod test_waveform_from_file_ffmpeg {
     use crate::WaveformArgs;
 
     #[track_caller]
-    #[inline(always)]
+    #[inline]
     fn assert_waveform(
         result: Result<Waveform, Error>,
         num_channels: u16,

--- a/src/backend/waveform_args.rs
+++ b/src/backend/waveform_args.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::backend::constants::*;
-
+use crate::backend::constants::{
+    DEFAULT_CONVERT_TO_MONO, DEFAULT_DECODING_BACKEND, DEFAULT_END_TIME_MILLISECONDS,
+    DEFAULT_FRAME_RATE_HZ, DEFAULT_NUM_CHANNELS, DEFAULT_RESAMPLE_MODE,
+    DEFAULT_START_TIME_MILLISECONDS, DEFAULT_ZERO_PAD_ENDING,
+};
 /// Specifies what transformations to apply to the audio during the decoding
 /// process.
 ///

--- a/src/frontends/c/build_info.rs
+++ b/src/frontends/c/build_info.rs
@@ -1,8 +1,11 @@
 use std::ffi::CString;
 use std::os::raw::c_char;
 
-use crate::backend::build_info::*;
-
+use crate::backend::build_info::{
+    babycat_version, compiled_with_ffmpeg, compiled_with_ffmpeg_build_link_static,
+    compiled_with_ffmpeg_link_static, compiled_with_filesystem, compiled_with_multithreading,
+    copyright_license_spdx,
+};
 /// Returns `true` if Babycat was compiled with support for
 /// reading and writing files to/from the local filesystem.
 ///
@@ -56,6 +59,7 @@ pub unsafe extern "C" fn babycat_build_info_compiled_with_ffmpeg_build_link_stat
 ///
 ///
 #[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_build_info_copyright_license_spdx() -> *const c_char {
     let c_string = CString::new(copyright_license_spdx()).unwrap();
@@ -68,6 +72,7 @@ pub unsafe extern "C" fn babycat_build_info_copyright_license_spdx() -> *const c
 /// of Babycat.
 ///
 #[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_build_info_version() -> *const c_char {
     let c_string = CString::new(babycat_version()).unwrap();

--- a/src/frontends/c/error.rs
+++ b/src/frontends/c/error.rs
@@ -60,15 +60,13 @@ pub fn error_to_num(err: Error) -> u32 {
 
         Error::UnknownInputEncoding => ERROR_UNKNOWN_INPUT_ENCODING,
 
-        Error::UnknownDecodeError => ERROR_UNKNOWN_DECODE_ERROR,
-
-        Error::UnknownDecodeErrorWithMessage(..) => ERROR_UNKNOWN_DECODE_ERROR,
+        Error::UnknownDecodeError | Error::UnknownDecodeErrorWithMessage(..) => {
+            ERROR_UNKNOWN_DECODE_ERROR
+        }
 
         Error::UnknownEncodeError => ERROR_UNKNOWN_ENCODE_ERROR,
 
-        Error::ResamplingError => ERROR_RESAMPLING_ERROR,
-
-        Error::ResamplingErrorWithMessage(..) => ERROR_RESAMPLING_ERROR,
+        Error::ResamplingError | Error::ResamplingErrorWithMessage(..) => ERROR_RESAMPLING_ERROR,
 
         Error::WrongFrameRate(..) => ERROR_WRONG_FRAME_RATE,
 

--- a/src/frontends/c/waveform.rs
+++ b/src/frontends/c/waveform.rs
@@ -8,9 +8,7 @@ use crate::frontends::c::waveform_result::WaveformResult;
 /// Returns a `babycat_WaveformArgs` struct with all default values.
 #[no_mangle]
 pub extern "C" fn babycat_waveform_args_init_default() -> WaveformArgs {
-    WaveformArgs {
-        ..Default::default()
-    }
+    WaveformArgs::default()
 }
 
 /// Frees a `babycat_Waveform` struct.
@@ -42,6 +40,7 @@ pub extern "C" fn babycat_waveform_from_frames_of_silence(
 /// @param duration_milliseconds The length of the audio waveform in milliseconds.
 ///
 #[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_panics_doc)]
 #[no_mangle]
 pub extern "C" fn babycat_waveform_from_milliseconds_of_silence(
     frame_rate_hz: u32,
@@ -63,6 +62,7 @@ pub extern "C" fn babycat_waveform_from_milliseconds_of_silence(
 ///        the encoding of the audio in `encoded_bytes`.
 ///
 #[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_waveform_from_encoded_bytes_with_hint(
     encoded_bytes: *mut u8,
@@ -108,6 +108,7 @@ pub unsafe extern "C" fn babycat_waveform_from_encoded_bytes(
 /// @param waveform_args Instructions on how to decode the audio.
 ///
 #[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_waveform_from_file(
     filename: *const c_char,
@@ -160,6 +161,7 @@ pub unsafe extern "C" fn babycat_waveform_get_num_samples(waveform: *mut Wavefor
 /// @param waveform A pointer to the `babycat_Waveform`.
 ///
 #[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_panics_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn babycat_waveform_to_interleaved_samples(
     waveform: *mut Waveform,

--- a/src/frontends/python/batch.rs
+++ b/src/frontends/python/batch.rs
@@ -156,6 +156,7 @@ use pyo3::wrap_pyfunction;
     num_workers = 0,
 )")]
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::needless_pass_by_value)]
 pub fn waveforms_from_files(
     filenames: Vec<String>,
     start_time_milliseconds: usize,
@@ -179,7 +180,7 @@ pub fn waveforms_from_files(
         decoding_backend,
     };
     let batch_args = crate::backend::BatchArgs { num_workers };
-    let filenames_ref: Vec<&str> = filenames.iter().map(|f| f.as_str()).collect();
+    let filenames_ref: Vec<&str> = filenames.iter().map(String::as_str).collect();
     crate::backend::batch::waveforms_from_files(&filenames_ref, waveform_args, batch_args)
         .into_iter()
         .map(crate::frontends::python::waveform_named_result::WaveformNamedResult::from)
@@ -213,6 +214,7 @@ pub fn waveforms_from_files(
     num_workers = 0,
 )")]
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::needless_pass_by_value)]
 pub fn waveforms_from_files_to_numpy_arrays(
     filenames: Vec<String>,
     start_time_milliseconds: usize,
@@ -236,7 +238,7 @@ pub fn waveforms_from_files_to_numpy_arrays(
         decoding_backend,
     };
     let batch_args = crate::backend::BatchArgs { num_workers };
-    let filenames_ref: Vec<&str> = filenames.iter().map(|f| f.as_str()).collect();
+    let filenames_ref: Vec<&str> = filenames.iter().map(String::as_str).collect();
     crate::backend::batch::waveforms_from_files(&filenames_ref, waveform_args, batch_args)
         .into_iter()
         .map(crate::frontends::python::numpy_named_result::NumPyNamedResult::from)

--- a/src/frontends/python/exceptions.rs
+++ b/src/frontends/python/exceptions.rs
@@ -61,9 +61,9 @@ impl std::convert::From<Error> for PyErr {
 
             Error::UnknownEncodeError => UnknownEncodeError::new_err(err.to_string()),
 
-            Error::ResamplingError => ResamplingError::new_err(err.to_string()),
-
-            Error::ResamplingErrorWithMessage(..) => ResamplingError::new_err(err.to_string()),
+            Error::ResamplingError | Error::ResamplingErrorWithMessage(..) => {
+                ResamplingError::new_err(err.to_string())
+            }
 
             Error::WrongFrameRate(..) => WrongFrameRate::new_err(err.to_string()),
 

--- a/src/frontends/python/waveform.rs
+++ b/src/frontends/python/waveform.rs
@@ -278,8 +278,9 @@ impl Waveform {
         frame_rate_hz,
         arr,
     )")]
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::needless_pass_by_value)]
     pub fn from_numpy(frame_rate_hz: u32, arr: PyReadonlyArray2<f32>) -> PyResult<Self> {
+        #[allow(clippy::cast_possible_truncation)]
         let num_channels: u16 = arr.shape()[1] as u16;
         waveform_result_to_pyresult(Ok(crate::backend::Waveform::new(
             frame_rate_hz,
@@ -444,7 +445,7 @@ impl Waveform {
     )")]
     #[allow(clippy::too_many_arguments)]
     pub fn from_encoded_bytes(
-        encoded_bytes: Vec<u8>,
+        encoded_bytes: &[u8],
         start_time_milliseconds: usize,
         end_time_milliseconds: usize,
         frame_rate_hz: u32,
@@ -467,7 +468,7 @@ impl Waveform {
             decoding_backend,
         };
         waveform_result_to_pyresult(crate::backend::Waveform::from_encoded_bytes_with_hint(
-            &encoded_bytes,
+            encoded_bytes,
             waveform_args,
             file_extension,
             mime_type,
@@ -504,7 +505,7 @@ impl Waveform {
     )")]
     #[allow(clippy::too_many_arguments)]
     pub fn from_encoded_bytes_into_numpy(
-        encoded_bytes: Vec<u8>,
+        encoded_bytes: &[u8],
         start_time_milliseconds: usize,
         end_time_milliseconds: usize,
         frame_rate_hz: u32,
@@ -527,7 +528,7 @@ impl Waveform {
             decoding_backend,
         };
         waveform_result_to_numpy_pyresult(crate::backend::Waveform::from_encoded_bytes_with_hint(
-            &encoded_bytes,
+            encoded_bytes,
             waveform_args,
             file_extension,
             mime_type,

--- a/src/frontends/python/waveform_named_result.rs
+++ b/src/frontends/python/waveform_named_result.rs
@@ -21,6 +21,7 @@ impl WaveformNamedResult {
         self.error.map(PyErr::from)
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!("{}", self))
     }

--- a/src/frontends/wasm/error.rs
+++ b/src/frontends/wasm/error.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use wasm_bindgen::prelude::*;
 
+#[allow(clippy::module_name_repetitions)]
 pub fn throw_js_error<E: Display>(err: E) -> JsValue {
     let err_string: String = err.to_string();
     js_sys::Error::new(&err_string).into()

--- a/src/frontends/wasm/mod.rs
+++ b/src/frontends/wasm/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_pass_by_value)]
 mod build_info;
 mod error;
 mod waveform;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,15 @@
 //!     }
 //! }
 //! ```
-
+#![warn(clippy::pedantic)]
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::used_underscore_binding)]
+#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::default_trait_access)]
 #![doc(
     html_logo_url = "https://static.neocrym.com/images/babycat/v1/1x/babycat-face-icon-on-transparent--1x.png"
 )]

--- a/tests/test_waveform_source.rs
+++ b/tests/test_waveform_source.rs
@@ -8,7 +8,7 @@ mod test_waveform_source {
 
     pub const COF_NUM_SAMPLES: usize = COF_NUM_FRAMES * COF_NUM_CHANNELS as usize;
 
-    #[inline(always)]
+    #[inline]
     #[track_caller]
     fn assert_ws(ws: &WaveformSource, num_channels: u16, frame_rate_hz: u32, num_samples: usize) {
         let num_frames = num_samples / num_channels as usize;


### PR DESCRIPTION
We enable cargo clippy's pedantic mode. As part of that, we eliminate
our use of the `inline(always)` macro.

We also either fix or annotate various numerical issues caused
when we convert from one type to another type.
