### PR TITLE
Add the `get_sample()` and `get_unchecked_sample()` methods for indexing samples in Waveforms

### DIFF
--- a/docs/source/api/c/babycat_Waveform/babycat_waveform_get_unchecked_sample.rst
+++ b/docs/source/api/c/babycat_Waveform/babycat_waveform_get_unchecked_sample.rst
@@ -1,0 +1,4 @@
+babycat_waveform_get_unchecked_sample()
+=======================================
+
+.. doxygenfunction:: babycat_waveform_get_unchecked_sample

--- a/docs/source/api/c/babycat_Waveform/index.rst
+++ b/docs/source/api/c/babycat_Waveform/index.rst
@@ -10,6 +10,7 @@ babycat_Waveform
    babycat_waveform_get_num_channels
    babycat_waveform_get_num_frames
    babycat_waveform_get_num_samples
+   babycat_waveform_get_unchecked_sample
    babycat_waveform_to_interleaved_samples
    babycat_waveform_from_frames_of_silence
    babycat_waveform_from_milliseconds_of_silence
@@ -35,6 +36,11 @@ Waveform properties
 - :doc:`babycat_waveform_get_num_channels`
 - :doc:`babycat_waveform_get_num_frames`
 - :doc:`babycat_waveform_get_num_samples`
+
+
+Indexing waveforms
+------------------
+- :doc:`babycat_waveform_get_unchecked_sample`
 
 
 Generating waveform from silence

--- a/docs/source/api/python/Waveform/get_sample.rst
+++ b/docs/source/api/python/Waveform/get_sample.rst
@@ -1,0 +1,4 @@
+Waveform.get_sample()
+=====================
+
+.. automethod:: babycat.Waveform.get_sample

--- a/docs/source/api/python/Waveform/get_unchecked_sample.rst
+++ b/docs/source/api/python/Waveform/get_unchecked_sample.rst
@@ -1,0 +1,4 @@
+Waveform.get_unchecked_sample()
+===============================
+
+.. automethod:: babycat.Waveform.get_unchecked_sample

--- a/docs/source/api/python/Waveform/index.rst
+++ b/docs/source/api/python/Waveform/index.rst
@@ -14,6 +14,15 @@ Waveform properties
    .num_frames <num_frames>
 
 
+Indexing waveforms
+------------------
+.. toctree::
+   :maxdepth: 2
+
+   .get_sample() <get_sample>
+   .get_unchecked_sample() <get_unchecked_sample>
+
+
 Generating waveforms from silence
 ---------------------------------
 .. toctree::

--- a/docs/source/api/wasm/Waveform/getSample.rst
+++ b/docs/source/api/wasm/Waveform/getSample.rst
@@ -1,0 +1,4 @@
+Waveform.getSample()
+====================
+
+.. js:autofunction:: getSample

--- a/docs/source/api/wasm/Waveform/getUncheckedSample.rst
+++ b/docs/source/api/wasm/Waveform/getUncheckedSample.rst
@@ -1,0 +1,4 @@
+Waveform.getUncheckedSample()
+=============================
+
+.. js:autofunction:: getUncheckedSample

--- a/docs/source/api/wasm/Waveform/index.rst
+++ b/docs/source/api/wasm/Waveform/index.rst
@@ -8,6 +8,8 @@ babycat.Waveform
    .frameRateHz() <frameRateHz>
    .numChannels() <numChannels>
    .numFrames() <numFrames>
+   .getSample() <getSample>
+   .getUncheckedSample <getUncheckedSample>
    .fromFramesOfSilence() <fromFramesOfSilence>
    .fromMillisecondsOfSilence() <fromMillisecondsOfSilence>
    .fromEncodedArray() <fromEncodedArray>
@@ -26,6 +28,12 @@ Waveform properties
 - :doc:`frameRateHz`
 - :doc:`numChannels`
 - :doc:`numFrames`
+
+
+Indexing waveforms
+------------------
+- :doc:`getSample`
+- :doc:`getUncheckedSample`
 
 
 Generating waveform from silence

--- a/src/frontends/c/waveform.rs
+++ b/src/frontends/c/waveform.rs
@@ -169,6 +169,30 @@ pub unsafe extern "C" fn babycat_waveform_to_interleaved_samples(
     waveform.as_ref().unwrap().to_interleaved_samples().as_ptr()
 }
 
+/// Return a given audio sample belonging to a specific frame and channel.
+///
+/// @param waveform A pointer to the `babycat_Waveform` to query.
+/// @param frame_idx The given frame.
+/// @param channel_idx The given channel.
+///
+/// This method does not perform any bounds-checking.
+/// It is memory-unsafe if `frame_idx` is above the number
+/// of frames and `channel_idx` is above the number of channels.
+///
+#[allow(clippy::missing_safety_doc)]
+#[allow(clippy::missing_panics_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn babycat_waveform_get_unchecked_sample(
+    waveform: *mut Waveform,
+    frame_idx: usize,
+    channel_idx: u16,
+) -> f32 {
+    waveform
+        .as_ref()
+        .unwrap()
+        .get_unchecked_sample(frame_idx, channel_idx)
+}
+
 /// Resample a `babycat_Waveform` with the default resampler.
 ///
 /// @param waveform A pointer to the `babycat_Waveform` to resample.

--- a/src/frontends/python/waveform.rs
+++ b/src/frontends/python/waveform.rs
@@ -1030,6 +1030,58 @@ impl Waveform {
         waveform_result_to_pyresult(self.inner.resample_by_mode(frame_rate_hz, resample_mode))
     }
 
+    /// Return a given audio sample belonging to a specific frame and channel.
+    ///
+    /// This method performs bounds checks. If you want an unsafe
+    /// method that does not perform bounds checks, use
+    /// :py:meth:`get_unchecked_sample`.
+    ///
+    /// Args:
+    ///     frame_idx: The index of the given frame to query.
+    ///
+    ///     channel_idx: the index of the given channel to query.
+    ///
+    /// Returns:
+    ///     Returns ``None`` if ``frame_idx`` or  ``channel_idx``
+    ///     is out-of-bounds. Otherwise, it returns an Audio sample as
+    ///     a native Python 64-bit :py:class:`float` value.
+    ///
+    #[args(frame_idx, channel_idx)]
+    #[pyo3(text_signature = "(
+        self,
+        frame_idx,
+        channel_idx,
+    )")]
+    pub fn get_sample(&self, frame_idx: usize, channel_idx: u16) -> Option<f32> {
+        self.inner.get_sample(frame_idx, channel_idx)
+    }
+
+    /// Return a given audio sample belonging to a specific frame and channel,
+    /// *without* performing any bounds checks.
+    ///
+    /// If you want bounds checking, use the :py:meth:`get_sample` method.
+    ///
+    /// Args:
+    ///     frame_idx: The index of the given frame to query.
+    ///
+    ///     channel_idx: the index of the given channel to query.
+    ///
+    /// Returns:
+    ///     Returns ``None`` if ``frame_idx`` or ``channel_idx``
+    ///     is out-of-bounds. Otherwise, it returns an Audio sample as
+    ///     a native Python 64-bit :py:class:`float` value.
+    ///
+    #[args(frame_idx, channel_idx)]
+    #[pyo3(text_signature = "(
+        self,
+        frame_idx,
+        channel_idx,
+    )")]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn get_unchecked_sample(&self, frame_idx: usize, channel_idx: u16) -> f32 {
+        self.inner.get_unchecked_sample(frame_idx, channel_idx)
+    }
+
     /// Returns the audio waveform as a Python list of interleaved samples.
     #[args()]
     #[pyo3(text_signature = "()")]

--- a/src/frontends/wasm/waveform.rs
+++ b/src/frontends/wasm/waveform.rs
@@ -116,6 +116,17 @@ impl Waveform {
         self.inner.num_frames()
     }
 
+    /// Return a given audio sample belonging to a specific frame and channel.
+    pub fn getSample(&self, frame_idx: usize, channel_idx: u16) -> Option<f32> {
+        self.inner.get_sample(frame_idx, channel_idx)
+    }
+
+    /// Return a given audio sample belonging to a specific frame and channel without
+    /// performing bounds checks.
+    pub fn getUncheckedSample(&self, frame_idx: usize, channel_idx: u16) -> f32 {
+        unsafe { self.inner.get_unchecked_sample(frame_idx, channel_idx) }
+    }
+
     /// Resamples the waveform using the default resampler.
     pub fn resample(&self, frameRateHz: u32) -> Result<Waveform, JsValue> {
         match self.inner.resample(frameRateHz) {

--- a/tests-python/test_waveform_from_interleaved_samples.py
+++ b/tests-python/test_waveform_from_interleaved_samples.py
@@ -1,6 +1,8 @@
 """
 Test loading waveforms from 1-D Python lists.
 """
+import numpy as np
+
 from babycat import Waveform
 
 
@@ -39,3 +41,57 @@ def test_four_frames_three_channels():
         interleaved_samples=interleaved_samples,
     )
     assert interleaved_samples == waveform.to_interleaved_samples()
+
+
+def test_five_frames_three_channels_1():
+    interleaved_samples = [
+        -1.0,
+        -0.9,
+        -0.8,
+        -0.7,
+        -0.6,
+        -0.5,
+        -0.4,
+        -0.3,
+        -0.2,
+        -0.1,
+        0.0,
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+    ]
+    waveform = Waveform.from_interleaved_samples(
+        frame_rate_hz=44_100,
+        num_channels=3,
+        interleaved_samples=interleaved_samples,
+    )
+    assert waveform.num_channels == 3
+    assert waveform.num_frames == 5
+    assert waveform.frame_rate_hz == 44100
+    #
+    # Try fetching nonexistent values and receive a None response.
+    assert waveform.get_sample(0, 3) is None
+    assert waveform.get_sample(5, 0) is None
+    assert waveform.get_sample(5, 3) is None
+    #
+    # Fetch every single value with get_sample() and verify it is correct.
+    assert waveform.get_sample(0, 0) == np.float32(-1.0)
+    assert waveform.get_sample(0, 1) == np.float32(-0.9)
+    assert waveform.get_sample(0, 2) == np.float32(-0.8)
+    #
+    assert waveform.get_sample(1, 0) == np.float32(-0.7)
+    assert waveform.get_sample(1, 1) == np.float32(-0.6)
+    assert waveform.get_sample(1, 2) == np.float32(-0.5)
+    #
+    assert waveform.get_sample(2, 0) == np.float32(-0.4)
+    assert waveform.get_sample(2, 1) == np.float32(-0.3)
+    assert waveform.get_sample(2, 2) == np.float32(-0.2)
+    #
+    assert waveform.get_sample(3, 0) == np.float32(-0.1)
+    assert waveform.get_sample(3, 1) == np.float32(0.0)
+    assert waveform.get_sample(3, 2) == np.float32(0.1)
+    #
+    assert waveform.get_sample(4, 0) == np.float32(0.2)
+    assert waveform.get_sample(4, 1) == np.float32(0.3)
+    assert waveform.get_sample(4, 2) == np.float32(0.4)

--- a/tests/test_waveform_from_interleaved_samples.rs
+++ b/tests/test_waveform_from_interleaved_samples.rs
@@ -15,4 +15,70 @@ mod test_waveform_from_interleaved_samples {
         assert_eq!(waveform.num_frames(), 4);
         assert_eq!(waveform.frame_rate_hz(), 44100);
     }
+
+    #[test]
+    fn test_five_frames_three_channels_1() {
+        let interleaved_samples: Vec<f32> = vec![
+            -1.0, -0.9, -0.8, //
+            -0.7, -0.6, -0.5, //
+            -0.4, -0.3, -0.2, //
+            -0.1, 0.0, 0.1, //
+            0.2, 0.3, 0.4,
+        ];
+        let waveform = Waveform::from_interleaved_samples(44100, 3, &interleaved_samples);
+        assert_eq!(waveform.num_channels(), 3);
+        assert_eq!(waveform.num_frames(), 5);
+        assert_eq!(waveform.frame_rate_hz(), 44100);
+        //
+        // Try fetching nonexistent values and receive a None response.
+        assert_eq!(waveform.get_sample(0, 3), None);
+        assert_eq!(waveform.get_sample(5, 0), None);
+        assert_eq!(waveform.get_sample(5, 3), None);
+        //
+        // Fetch every single value with get_sample().
+        assert_eq!(waveform.get_sample(0, 0).unwrap(), -1.0);
+        assert_eq!(waveform.get_sample(0, 1).unwrap(), -0.9);
+        assert_eq!(waveform.get_sample(0, 2).unwrap(), -0.8);
+        //
+        assert_eq!(waveform.get_sample(1, 0).unwrap(), -0.7);
+        assert_eq!(waveform.get_sample(1, 1).unwrap(), -0.6);
+        assert_eq!(waveform.get_sample(1, 2).unwrap(), -0.5);
+        //
+        assert_eq!(waveform.get_sample(2, 0).unwrap(), -0.4);
+        assert_eq!(waveform.get_sample(2, 1).unwrap(), -0.3);
+        assert_eq!(waveform.get_sample(2, 2).unwrap(), -0.2);
+        //
+        assert_eq!(waveform.get_sample(3, 0).unwrap(), -0.1);
+        assert_eq!(waveform.get_sample(3, 1).unwrap(), 0.0);
+        assert_eq!(waveform.get_sample(3, 2).unwrap(), 0.1);
+        //
+        assert_eq!(waveform.get_sample(4, 0).unwrap(), 0.2);
+        assert_eq!(waveform.get_sample(4, 1).unwrap(), 0.3);
+        assert_eq!(waveform.get_sample(4, 2).unwrap(), 0.4);
+        //
+        //
+        unsafe {
+            assert_eq!(waveform.get_unchecked_sample(0, 0), -1.0);
+            assert_eq!(waveform.get_unchecked_sample(0, 1), -0.9);
+            assert_eq!(waveform.get_unchecked_sample(0, 2), -0.8);
+
+            assert_eq!(waveform.get_unchecked_sample(1, 0), -0.7);
+            assert_eq!(waveform.get_unchecked_sample(1, 1), -0.6);
+            assert_eq!(waveform.get_unchecked_sample(1, 2), -0.5);
+
+            assert_eq!(waveform.get_unchecked_sample(2, 0), -0.4);
+            assert_eq!(waveform.get_unchecked_sample(2, 1), -0.3);
+            assert_eq!(waveform.get_unchecked_sample(2, 2), -0.2);
+
+            assert_eq!(waveform.get_unchecked_sample(3, 0), -0.1);
+            assert_eq!(waveform.get_unchecked_sample(3, 1), 0.0);
+            assert_eq!(waveform.get_unchecked_sample(3, 2), 0.1);
+
+            assert_eq!(waveform.get_unchecked_sample(4, 0), 0.2);
+            assert_eq!(waveform.get_unchecked_sample(4, 1), 0.3);
+            assert_eq!(waveform.get_unchecked_sample(4, 2), 0.4);
+        }
+        let interleaved_samples_2: Vec<f32> = waveform.to_interleaved_samples().to_vec();
+        assert_eq!(interleaved_samples, interleaved_samples_2);
+    }
 }


### PR DESCRIPTION
The `get_sample()` and `get_unchecked_sample()` methods allow for fetching individual `f32` audio samples without creating a `Vec` or a `&[f32]` slice.