### PR TITLE
makefile: Fix `fmt-check-rust` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,9 @@ fmt-check-python: .b/init-python-dev
 .PHONY: fmt-check-python
 
 fmt-check-rust: .b/init-cargo-fmt
-	$(CARGO) fmt --check
+	$(CARGO) fmt --help || true
+	$(CARGO) fmt --check || true
+	$(CARGO) fmt -- --check || true
 .PHONY: fmt-check-rust
 
 fmt-check: fmt-check-c fmt-check-javascript fmt-check-python fmt-check-rust

--- a/Makefile
+++ b/Makefile
@@ -353,9 +353,7 @@ fmt-check-python: .b/init-python-dev
 .PHONY: fmt-check-python
 
 fmt-check-rust: .b/init-cargo-fmt
-	$(CARGO) fmt --help || true
-	$(CARGO) fmt --check || true
-	$(CARGO) fmt -- --check || true
+	$(CARGO) fmt -- --check
 .PHONY: fmt-check-rust
 
 fmt-check: fmt-check-c fmt-check-javascript fmt-check-python fmt-check-rust


### PR DESCRIPTION
It seems like we need a `--` between the command line arguments
that belong to `cargo` vs. `rustfmt`.