### PR TITLE
Stop trying to build FFmpeg on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ frontend-c = [
 [package.metadata.docs.rs]
 # When building Rust documentation to publish on docs.rs,
 # enable the FFmpeg features.
-features = ["frontend-rust", "enable-ffmpeg-build"]
+features = ["frontend-rust"]
 all-features = false
 no-default-features = false
 


### PR DESCRIPTION
The Rust FFmpeg build script requires Internet access,
and the docs.rs build servers do not have Internet access
for security reasons.
