### PR TITLE
Docs: Add `Source` trait on babycat.io homepage example

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -163,7 +163,7 @@ This is an example of decoding a file named ``'audio.mp3'`` into memory and then
 
    .. code:: rust
 
-      use babycat::{WaveformArgs, Waveform};
+      use babycat::{Source, WaveformArgs, Waveform};
 
       fn main() {
          let waveform_args = WaveformArgs {


### PR DESCRIPTION
Previously the example was throwing a compile error.